### PR TITLE
Implement layout editor UI and property tooling

### DIFF
--- a/Launcher.LayoutEditor/App.config
+++ b/Launcher.LayoutEditor/App.config
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+</configuration>

--- a/Launcher.LayoutEditor/Launcher.LayoutEditor.csproj
+++ b/Launcher.LayoutEditor/Launcher.LayoutEditor.csproj
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{8F30A00D-1C72-4B70-AB6A-4D89CE801C64}</ProjectGuid>
+    <OutputType>WinExe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Launcher.LayoutEditor</RootNamespace>
+    <AssemblyName>Launcher.LayoutEditor</AssemblyName>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <StartupObject>Launcher.LayoutEditor.Program</StartupObject>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Design" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="MainForm.cs" />
+    <Compile Include="MainForm.Designer.cs">
+      <DependentUpon>MainForm.cs</DependentUpon>
+    </Compile>
+    <Compile Include="PropertyModels.cs" />
+    <Compile Include="RelativePathEditor.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="..\Launcher\Layout\LayoutDefinition.cs">
+      <Link>Layout\LayoutDefinition.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/Launcher.LayoutEditor/MainForm.Designer.cs
+++ b/Launcher.LayoutEditor/MainForm.Designer.cs
@@ -1,0 +1,218 @@
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace Launcher.LayoutEditor
+{
+    public partial class MainForm
+    {
+        private MenuStrip menuStrip1;
+        private ToolStripMenuItem fileToolStripMenuItem;
+        private ToolStripMenuItem openToolStripMenuItem;
+        private ToolStripMenuItem saveToolStripMenuItem;
+        private ToolStripMenuItem saveAsToolStripMenuItem;
+        private ToolStripMenuItem setAssetFolderToolStripMenuItem;
+        private ToolStripMenuItem exitToolStripMenuItem;
+        private ToolStripMenuItem insertToolStripMenuItem;
+        private ToolStripMenuItem addDynamicButtonToolStripMenuItem;
+        private ToolStripMenuItem editToolStripMenuItem;
+        private ToolStripMenuItem deleteSelectedToolStripMenuItem;
+        private SplitContainer splitContainer1;
+        private Panel designPanel;
+        private PropertyGrid propertyGrid1;
+        private StatusStrip statusStrip1;
+        private ToolStripStatusLabel statusLabelPath;
+
+        private void InitializeComponent()
+        {
+            this.menuStrip1 = new MenuStrip();
+            this.fileToolStripMenuItem = new ToolStripMenuItem();
+            this.openToolStripMenuItem = new ToolStripMenuItem();
+            this.saveToolStripMenuItem = new ToolStripMenuItem();
+            this.saveAsToolStripMenuItem = new ToolStripMenuItem();
+            this.setAssetFolderToolStripMenuItem = new ToolStripMenuItem();
+            this.exitToolStripMenuItem = new ToolStripMenuItem();
+            this.insertToolStripMenuItem = new ToolStripMenuItem();
+            this.addDynamicButtonToolStripMenuItem = new ToolStripMenuItem();
+            this.editToolStripMenuItem = new ToolStripMenuItem();
+            this.deleteSelectedToolStripMenuItem = new ToolStripMenuItem();
+            this.splitContainer1 = new SplitContainer();
+            this.designPanel = new Panel();
+            this.propertyGrid1 = new PropertyGrid();
+            this.statusStrip1 = new StatusStrip();
+            this.statusLabelPath = new ToolStripStatusLabel();
+            this.menuStrip1.SuspendLayout();
+            this.splitContainer1.Panel1.SuspendLayout();
+            this.splitContainer1.Panel2.SuspendLayout();
+            this.splitContainer1.SuspendLayout();
+            this.statusStrip1.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // menuStrip1
+            // 
+            this.menuStrip1.Items.AddRange(new ToolStripItem[]
+            {
+                this.fileToolStripMenuItem,
+                this.insertToolStripMenuItem,
+                this.editToolStripMenuItem
+            });
+            this.menuStrip1.Location = new System.Drawing.Point(0, 0);
+            this.menuStrip1.Name = "menuStrip1";
+            this.menuStrip1.Size = new System.Drawing.Size(1084, 24);
+            this.menuStrip1.TabIndex = 0;
+            this.menuStrip1.Text = "menuStrip1";
+            // 
+            // fileToolStripMenuItem
+            // 
+            this.fileToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[]
+            {
+                this.openToolStripMenuItem,
+                this.saveToolStripMenuItem,
+                this.saveAsToolStripMenuItem,
+                this.setAssetFolderToolStripMenuItem,
+                this.exitToolStripMenuItem
+            });
+            this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
+            this.fileToolStripMenuItem.Text = "File";
+            // 
+            // openToolStripMenuItem
+            // 
+            this.openToolStripMenuItem.Name = "openToolStripMenuItem";
+            this.openToolStripMenuItem.Size = new System.Drawing.Size(167, 22);
+            this.openToolStripMenuItem.Text = "Open...";
+            this.openToolStripMenuItem.Click += new System.EventHandler(this.OpenToolStripMenuItem_Click);
+            // 
+            // saveToolStripMenuItem
+            // 
+            this.saveToolStripMenuItem.Name = "saveToolStripMenuItem";
+            this.saveToolStripMenuItem.Size = new System.Drawing.Size(167, 22);
+            this.saveToolStripMenuItem.Text = "Save";
+            this.saveToolStripMenuItem.Click += new System.EventHandler(this.SaveToolStripMenuItem_Click);
+            // 
+            // saveAsToolStripMenuItem
+            // 
+            this.saveAsToolStripMenuItem.Name = "saveAsToolStripMenuItem";
+            this.saveAsToolStripMenuItem.Size = new System.Drawing.Size(167, 22);
+            this.saveAsToolStripMenuItem.Text = "Save As...";
+            this.saveAsToolStripMenuItem.Click += new System.EventHandler(this.SaveAsToolStripMenuItem_Click);
+            // 
+            // setAssetFolderToolStripMenuItem
+            // 
+            this.setAssetFolderToolStripMenuItem.Name = "setAssetFolderToolStripMenuItem";
+            this.setAssetFolderToolStripMenuItem.Size = new System.Drawing.Size(167, 22);
+            this.setAssetFolderToolStripMenuItem.Text = "Set Asset Folder";
+            this.setAssetFolderToolStripMenuItem.Click += new System.EventHandler(this.SetAssetFolderToolStripMenuItem_Click);
+            // 
+            // exitToolStripMenuItem
+            // 
+            this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
+            this.exitToolStripMenuItem.Size = new System.Drawing.Size(167, 22);
+            this.exitToolStripMenuItem.Text = "Exit";
+            this.exitToolStripMenuItem.Click += new System.EventHandler(this.ExitToolStripMenuItem_Click);
+            // 
+            // insertToolStripMenuItem
+            // 
+            this.insertToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[]
+            {
+                this.addDynamicButtonToolStripMenuItem
+            });
+            this.insertToolStripMenuItem.Name = "insertToolStripMenuItem";
+            this.insertToolStripMenuItem.Size = new System.Drawing.Size(48, 20);
+            this.insertToolStripMenuItem.Text = "Insert";
+            // 
+            // addDynamicButtonToolStripMenuItem
+            // 
+            this.addDynamicButtonToolStripMenuItem.Name = "addDynamicButtonToolStripMenuItem";
+            this.addDynamicButtonToolStripMenuItem.Size = new System.Drawing.Size(182, 22);
+            this.addDynamicButtonToolStripMenuItem.Text = "Dynamic Button";
+            this.addDynamicButtonToolStripMenuItem.Click += new System.EventHandler(this.AddDynamicButtonToolStripMenuItem_Click);
+            // 
+            // editToolStripMenuItem
+            // 
+            this.editToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[]
+            {
+                this.deleteSelectedToolStripMenuItem
+            });
+            this.editToolStripMenuItem.Name = "editToolStripMenuItem";
+            this.editToolStripMenuItem.Size = new System.Drawing.Size(39, 20);
+            this.editToolStripMenuItem.Text = "Edit";
+            // 
+            // deleteSelectedToolStripMenuItem
+            // 
+            this.deleteSelectedToolStripMenuItem.Name = "deleteSelectedToolStripMenuItem";
+            this.deleteSelectedToolStripMenuItem.Size = new System.Drawing.Size(156, 22);
+            this.deleteSelectedToolStripMenuItem.Text = "Delete Selected";
+            this.deleteSelectedToolStripMenuItem.Click += new System.EventHandler(this.DeleteSelectedToolStripMenuItem_Click);
+            // 
+            // splitContainer1
+            // 
+            this.splitContainer1.Dock = DockStyle.Fill;
+            this.splitContainer1.Location = new System.Drawing.Point(0, 24);
+            this.splitContainer1.Name = "splitContainer1";
+            this.splitContainer1.Panel1.Controls.Add(this.designPanel);
+            this.splitContainer1.Panel2.Controls.Add(this.propertyGrid1);
+            this.splitContainer1.Size = new System.Drawing.Size(1084, 637);
+            this.splitContainer1.SplitterDistance = 760;
+            this.splitContainer1.TabIndex = 1;
+            // 
+            // designPanel
+            // 
+            this.designPanel.BackColor = Color.DimGray;
+            this.designPanel.Dock = DockStyle.Fill;
+            this.designPanel.Location = new System.Drawing.Point(0, 0);
+            this.designPanel.Name = "designPanel";
+            this.designPanel.Size = new System.Drawing.Size(760, 637);
+            this.designPanel.TabIndex = 0;
+            this.designPanel.MouseDown += new MouseEventHandler(this.DesignPanel_MouseDown);
+            // 
+            // propertyGrid1
+            // 
+            this.propertyGrid1.Dock = DockStyle.Fill;
+            this.propertyGrid1.Location = new System.Drawing.Point(0, 0);
+            this.propertyGrid1.Name = "propertyGrid1";
+            this.propertyGrid1.Size = new System.Drawing.Size(320, 637);
+            this.propertyGrid1.TabIndex = 0;
+            this.propertyGrid1.PropertyValueChanged += new PropertyValueChangedEventHandler(this.PropertyGrid1_PropertyValueChanged);
+            // 
+            // statusStrip1
+            // 
+            this.statusStrip1.Items.AddRange(new ToolStripItem[]
+            {
+                this.statusLabelPath
+            });
+            this.statusStrip1.Location = new System.Drawing.Point(0, 661);
+            this.statusStrip1.Name = "statusStrip1";
+            this.statusStrip1.Size = new System.Drawing.Size(1084, 22);
+            this.statusStrip1.TabIndex = 2;
+            this.statusStrip1.Text = "statusStrip1";
+            // 
+            // statusLabelPath
+            // 
+            this.statusLabelPath.Name = "statusLabelPath";
+            this.statusLabelPath.Size = new System.Drawing.Size(0, 17);
+            // 
+            // MainForm
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(1084, 683);
+            this.Controls.Add(this.splitContainer1);
+            this.Controls.Add(this.statusStrip1);
+            this.Controls.Add(this.menuStrip1);
+            this.MainMenuStrip = this.menuStrip1;
+            this.MinimumSize = new System.Drawing.Size(900, 600);
+            this.Name = "MainForm";
+            this.Text = "Layout Editor";
+            this.FormClosing += new FormClosingEventHandler(this.MainForm_FormClosing);
+            this.menuStrip1.ResumeLayout(false);
+            this.menuStrip1.PerformLayout();
+            this.splitContainer1.Panel1.ResumeLayout(false);
+            this.splitContainer1.Panel2.ResumeLayout(false);
+            this.splitContainer1.ResumeLayout(false);
+            this.statusStrip1.ResumeLayout(false);
+            this.statusStrip1.PerformLayout();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+        }
+    }
+}

--- a/Launcher.LayoutEditor/MainForm.cs
+++ b/Launcher.LayoutEditor/MainForm.cs
@@ -1,0 +1,1022 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
+using System.Windows.Forms;
+using Launcher.Layout;
+
+namespace Launcher.LayoutEditor
+{
+    public partial class MainForm : Form
+    {
+        private LayoutDefinition currentLayout;
+        private Panel layoutSurface;
+        private Panel selectionOverlay;
+        private Dictionary<Control, LayoutControl> staticControls;
+        private Dictionary<Control, DynamicButtonDefinition> dynamicControls;
+        private List<Image> loadedImages;
+        private Control selectedControl;
+        private object selectedDefinition;
+        private bool isDirty;
+        private bool isDragging;
+        private Point dragOffset;
+
+        public MainForm()
+        {
+            this.InitializeComponent();
+            this.currentLayout = new LayoutDefinition();
+            this.loadedImages = new List<Image>();
+            this.staticControls = new Dictionary<Control, LayoutControl>();
+            this.dynamicControls = new Dictionary<Control, DynamicButtonDefinition>();
+            this.designPanel.AutoScroll = true;
+            this.propertyGrid1.PropertySort = PropertySort.Categorized;
+            this.UpdateWindowTitle();
+            this.UpdateStatusLabel();
+            this.RefreshLayoutSurface(null);
+        }
+
+        private void OpenToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (!this.ConfirmDiscardChanges())
+            {
+                return;
+            }
+
+            using (OpenFileDialog dialog = new OpenFileDialog())
+            {
+                dialog.Filter = "Layout files (*.layout.xml)|*.layout.xml|XML files (*.xml)|*.xml|All files (*.*)|*.*";
+                dialog.Title = "Open Layout";
+                dialog.InitialDirectory = this.GetInitialLayoutDirectory();
+
+                if (dialog.ShowDialog(this) == DialogResult.OK)
+                {
+                    this.LoadLayout(dialog.FileName);
+                }
+            }
+        }
+
+        private void LoadLayout(string path)
+        {
+            try
+            {
+                LayoutDefinition definition = LayoutFile.Load(path);
+                if (definition.Form == null)
+                {
+                    definition.Form = new FormLayout();
+                }
+                this.currentLayout = definition;
+                this.currentLayout.SourcePath = path;
+                this.isDirty = false;
+                this.UpdateWindowTitle();
+                this.RefreshLayoutSurface(null);
+                this.UpdateStatusLabel();
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(this, "Failed to load layout: " + ex.Message, "Layout Editor", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+
+        private void SaveToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            this.SaveLayout(false);
+        }
+
+        private void SaveAsToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            this.SaveLayout(true);
+        }
+
+        private void SetAssetFolderToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            using (FolderBrowserDialog dialog = new FolderBrowserDialog())
+            {
+                dialog.Description = "Select asset folder";
+                string initial = this.GetAssetBaseDirectory();
+                if (!string.IsNullOrEmpty(initial) && Directory.Exists(initial))
+                {
+                    dialog.SelectedPath = initial;
+                }
+
+                if (dialog.ShowDialog(this) == DialogResult.OK)
+                {
+                    string relative = MakeRelativePath(this.GetLayoutDirectory(), dialog.SelectedPath);
+                    if (relative.Length == 0)
+                    {
+                        this.currentLayout.AssetDirectoryName = string.Empty;
+                    }
+                    else
+                    {
+                        this.currentLayout.AssetDirectoryName = NormalizeAssetPath(relative);
+                    }
+                    this.MarkDirty();
+                    this.RefreshLayoutSurface(this.selectedDefinition);
+                    this.UpdateStatusLabel();
+                }
+            }
+        }
+
+        private void ExitToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (this.ConfirmDiscardChanges())
+            {
+                this.Close();
+            }
+        }
+
+        private void AddDynamicButtonToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            DynamicButtonDefinition definition = new DynamicButtonDefinition();
+            definition.Name = this.GenerateDynamicButtonName();
+            definition.Target = definition.Name;
+            definition.Location = new Point(32, 32);
+            definition.Size = new Size(120, 32);
+            definition.Action = "OpenUrl";
+            definition.Argument = "https://example.com";
+            this.currentLayout.DynamicButtons.Add(definition);
+            this.MarkDirty();
+            this.RefreshLayoutSurface(definition);
+        }
+
+        private void DeleteSelectedToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (this.selectedDefinition is DynamicButtonDefinition)
+            {
+                DynamicButtonDefinition definition = (DynamicButtonDefinition)this.selectedDefinition;
+                DialogResult result = MessageBox.Show(this, "Remove dynamic button '" + definition.Name + "'?", "Layout Editor", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
+                if (result == DialogResult.Yes)
+                {
+                    this.currentLayout.DynamicButtons.Remove(definition);
+                    this.MarkDirty();
+                    this.RefreshLayoutSurface(null);
+                }
+            }
+            else
+            {
+                MessageBox.Show(this, "Select a dynamic button to delete.", "Layout Editor", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            }
+        }
+
+        private void PropertyGrid1_PropertyValueChanged(object s, PropertyValueChangedEventArgs e)
+        {
+            this.MarkDirty();
+            object target = null;
+            if (this.propertyGrid1.SelectedObject is IPropertyModel)
+            {
+                IPropertyModel model = (IPropertyModel)this.propertyGrid1.SelectedObject;
+                model.OnPropertyChanged();
+                target = model.Underlying;
+            }
+            this.RefreshLayoutSurface(target);
+        }
+
+        private void DesignPanel_MouseDown(object sender, MouseEventArgs e)
+        {
+            if (e.Button == MouseButtons.Left)
+            {
+                this.UpdateSelection(null, null);
+            }
+        }
+
+        private void LayoutSurface_MouseDown(object sender, MouseEventArgs e)
+        {
+            if (e.Button == MouseButtons.Left)
+            {
+                this.UpdateSelection(null, null);
+            }
+        }
+
+        private void Control_MouseDown(object sender, MouseEventArgs e)
+        {
+            Control control = sender as Control;
+            if (control == null)
+            {
+                return;
+            }
+
+            Control designControl = this.GetDesignControl(control);
+            object definition = this.GetDefinitionForControl(control);
+            this.UpdateSelection(designControl, definition);
+
+            if (designControl != null && e.Button == MouseButtons.Left && definition is DynamicButtonDefinition)
+            {
+                this.isDragging = true;
+                this.dragOffset = this.TranslateToDesignControl(designControl, control, e.Location);
+                designControl.Capture = true;
+            }
+        }
+
+        private void Control_MouseMove(object sender, MouseEventArgs e)
+        {
+            if (!this.isDragging)
+            {
+                return;
+            }
+
+            Control source = sender as Control;
+            if (source == null)
+            {
+                return;
+            }
+
+            Control control = this.GetDesignControl(source);
+            if (control == null)
+            {
+                return;
+            }
+
+            DynamicButtonDefinition definition;
+            if (!this.dynamicControls.TryGetValue(control, out definition))
+            {
+                return;
+            }
+
+            Point localPoint = this.TranslateToDesignControl(control, source, e.Location);
+
+            int newX = control.Left + localPoint.X - this.dragOffset.X;
+            int newY = control.Top + localPoint.Y - this.dragOffset.Y;
+            if (newX < 0)
+            {
+                newX = 0;
+            }
+            if (newY < 0)
+            {
+                newY = 0;
+            }
+            if (this.layoutSurface != null)
+            {
+                if (newX + control.Width > this.layoutSurface.Width)
+                {
+                    newX = this.layoutSurface.Width - control.Width;
+                }
+                if (newY + control.Height > this.layoutSurface.Height)
+                {
+                    newY = this.layoutSurface.Height - control.Height;
+                }
+            }
+
+            control.Location = new Point(newX, newY);
+            this.UpdateSelectionOverlay();
+            this.statusLabelPath.Text = "Position: " + newX + ", " + newY;
+        }
+
+        private void Control_MouseUp(object sender, MouseEventArgs e)
+        {
+            if (!this.isDragging)
+            {
+                return;
+            }
+
+            this.isDragging = false;
+            Control source = sender as Control;
+            if (source != null)
+            {
+                Control control = this.GetDesignControl(source);
+                if (control != null)
+                {
+                    control.Capture = false;
+                    DynamicButtonDefinition definition;
+                    if (this.dynamicControls.TryGetValue(control, out definition))
+                    {
+                        Point location = control.Location;
+                        definition.Location = location;
+                        this.MarkDirty();
+                        this.propertyGrid1.Refresh();
+                    }
+                }
+            }
+            this.UpdateStatusLabel();
+        }
+
+        private void MainForm_FormClosing(object sender, FormClosingEventArgs e)
+        {
+            if (!this.ConfirmDiscardChanges())
+            {
+                e.Cancel = true;
+            }
+        }
+
+        private bool SaveLayout(bool saveAs)
+        {
+            if (this.currentLayout == null)
+            {
+                return false;
+            }
+
+            string targetPath = this.currentLayout.SourcePath;
+            if (saveAs || string.IsNullOrEmpty(targetPath))
+            {
+                using (SaveFileDialog dialog = new SaveFileDialog())
+                {
+                    dialog.Filter = "Layout files (*.layout.xml)|*.layout.xml|XML files (*.xml)|*.xml|All files (*.*)|*.*";
+                    dialog.Title = "Save Layout";
+                    dialog.InitialDirectory = this.GetInitialLayoutDirectory();
+                    if (!string.IsNullOrEmpty(targetPath))
+                    {
+                        dialog.FileName = targetPath;
+                    }
+
+                    if (dialog.ShowDialog(this) != DialogResult.OK)
+                    {
+                        return false;
+                    }
+
+                    targetPath = dialog.FileName;
+                }
+            }
+
+            try
+            {
+                LayoutFile.Save(this.currentLayout, targetPath);
+                this.currentLayout.SourcePath = targetPath;
+                this.isDirty = false;
+                this.UpdateWindowTitle();
+                this.UpdateStatusLabel();
+                return true;
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(this, "Failed to save layout: " + ex.Message, "Layout Editor", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return false;
+            }
+        }
+
+        private bool ConfirmDiscardChanges()
+        {
+            if (!this.isDirty)
+            {
+                return true;
+            }
+
+            DialogResult result = MessageBox.Show(this, "Save changes to the current layout?", "Layout Editor", MessageBoxButtons.YesNoCancel, MessageBoxIcon.Question);
+            if (result == DialogResult.Cancel)
+            {
+                return false;
+            }
+
+            if (result == DialogResult.Yes)
+            {
+                return this.SaveLayout(false);
+            }
+
+            return true;
+        }
+
+        private void RefreshLayoutSurface(object definitionToSelect)
+        {
+            this.DisposeLoadedImages();
+            this.designPanel.SuspendLayout();
+            try
+            {
+                this.designPanel.Controls.Clear();
+                this.staticControls.Clear();
+                this.dynamicControls.Clear();
+                this.selectedControl = null;
+
+                Size clientSize = new Size(960, 540);
+                if (this.currentLayout != null && this.currentLayout.Form != null && !this.currentLayout.Form.ClientSize.IsEmpty)
+                {
+                    clientSize = this.currentLayout.Form.ClientSize;
+                }
+
+                this.designPanel.AutoScrollMinSize = new Size(clientSize.Width + 40, clientSize.Height + 40);
+
+                this.layoutSurface = new Panel();
+                this.layoutSurface.BackColor = Color.Black;
+                this.layoutSurface.BorderStyle = BorderStyle.FixedSingle;
+                this.layoutSurface.Location = new Point(20, 20);
+                this.layoutSurface.Size = clientSize;
+                this.layoutSurface.BackgroundImageLayout = ImageLayout.Stretch;
+                this.layoutSurface.MouseDown += new MouseEventHandler(this.LayoutSurface_MouseDown);
+
+                string background = this.ResolveAssetPath(this.currentLayout != null && this.currentLayout.Form != null ? this.currentLayout.Form.BackgroundImage : null);
+                if (!string.IsNullOrEmpty(background) && File.Exists(background))
+                {
+                    Image image = this.LoadImageCopy(background);
+                    if (image != null)
+                    {
+                        this.layoutSurface.BackgroundImage = image;
+                    }
+                }
+
+                this.designPanel.Controls.Add(this.layoutSurface);
+
+                foreach (LayoutControl layoutControl in this.currentLayout.Controls)
+                {
+                    Control visual = this.CreateControlVisual(layoutControl);
+                    if (visual != null)
+                    {
+                        this.layoutSurface.Controls.Add(visual);
+                        this.staticControls.Add(visual, layoutControl);
+                        this.AttachControlHandlers(visual);
+                    }
+                }
+
+                foreach (DynamicButtonDefinition dynamicButton in this.currentLayout.DynamicButtons)
+                {
+                    Control visual = this.CreateDynamicButtonVisual(dynamicButton);
+                    if (visual != null)
+                    {
+                        this.layoutSurface.Controls.Add(visual);
+                        this.dynamicControls.Add(visual, dynamicButton);
+                        this.AttachControlHandlers(visual);
+                    }
+                }
+
+                this.EnsureSelectionOverlay();
+
+                if (definitionToSelect == null)
+                {
+                    this.UpdateSelection(null, null);
+                }
+                else
+                {
+                    Control match = this.FindControlByDefinition(definitionToSelect);
+                    this.UpdateSelection(match, definitionToSelect);
+                }
+            }
+            finally
+            {
+                this.designPanel.ResumeLayout();
+            }
+        }
+
+        private void AttachControlHandlers(Control control)
+        {
+            this.AttachHandlersRecursive(control);
+            control.ControlAdded += new ControlEventHandler(this.Control_ControlAdded);
+        }
+
+        private void AttachHandlersRecursive(Control control)
+        {
+            control.MouseDown += new MouseEventHandler(this.Control_MouseDown);
+            control.MouseMove += new MouseEventHandler(this.Control_MouseMove);
+            control.MouseUp += new MouseEventHandler(this.Control_MouseUp);
+
+            foreach (Control child in control.Controls)
+            {
+                this.AttachHandlersRecursive(child);
+            }
+        }
+
+        private void Control_ControlAdded(object sender, ControlEventArgs e)
+        {
+            if (e != null && e.Control != null)
+            {
+                this.AttachHandlersRecursive(e.Control);
+            }
+        }
+
+        private Control FindControlByDefinition(object definition)
+        {
+            foreach (KeyValuePair<Control, LayoutControl> pair in this.staticControls)
+            {
+                if (object.ReferenceEquals(pair.Value, definition))
+                {
+                    return pair.Key;
+                }
+            }
+
+            foreach (KeyValuePair<Control, DynamicButtonDefinition> pair2 in this.dynamicControls)
+            {
+                if (object.ReferenceEquals(pair2.Value, definition))
+                {
+                    return pair2.Key;
+                }
+            }
+
+            return null;
+        }
+
+        private object GetDefinitionForControl(Control control)
+        {
+            Control current = control;
+            while (current != null && current != this.layoutSurface)
+            {
+                LayoutControl staticDefinition;
+                if (this.staticControls.TryGetValue(current, out staticDefinition))
+                {
+                    return staticDefinition;
+                }
+
+                DynamicButtonDefinition dynamicDefinition;
+                if (this.dynamicControls.TryGetValue(current, out dynamicDefinition))
+                {
+                    return dynamicDefinition;
+                }
+
+                current = current.Parent;
+            }
+
+            return null;
+        }
+
+        private Control GetDesignControl(Control control)
+        {
+            Control current = control;
+            while (current != null && current.Parent != this.layoutSurface && current != this.layoutSurface)
+            {
+                current = current.Parent;
+            }
+
+            if (current == this.layoutSurface)
+            {
+                return null;
+            }
+
+            return current;
+        }
+
+        private Point TranslateToDesignControl(Control designControl, Control sourceControl, Point sourcePoint)
+        {
+            if (designControl == null || sourceControl == null)
+            {
+                return sourcePoint;
+            }
+
+            if (designControl == sourceControl)
+            {
+                return sourcePoint;
+            }
+
+            Point screenPoint = sourceControl.PointToScreen(sourcePoint);
+            Point translated = designControl.PointToClient(screenPoint);
+            return translated;
+        }
+
+        private Control CreateControlVisual(LayoutControl definition)
+        {
+            Control control = null;
+            switch (definition.Type)
+            {
+                case LayoutControlType.Label:
+                    Label label = new Label();
+                    label.Text = definition.Text;
+                    if (definition.AutoSize.HasValue)
+                    {
+                        label.AutoSize = definition.AutoSize.Value;
+                    }
+                    label.TextAlign = definition.TextAlign.HasValue ? definition.TextAlign.Value : ContentAlignment.TopLeft;
+                    control = label;
+                    break;
+                case LayoutControlType.PictureBox:
+                    PictureBox pictureBox = new PictureBox();
+                    pictureBox.BackgroundImageLayout = ParseImageLayout(definition.BackgroundLayout);
+                    pictureBox.SizeMode = definition.SizeMode.HasValue ? definition.SizeMode.Value : PictureBoxSizeMode.Normal;
+                    Image pictureBackground = this.LoadImageCopy(this.ResolveAssetPath(definition.BackgroundImage));
+                    if (pictureBackground != null)
+                    {
+                        pictureBox.BackgroundImage = pictureBackground;
+                    }
+                    Image mainImage = this.LoadImageCopy(this.ResolveAssetPath(definition.Image));
+                    if (mainImage != null)
+                    {
+                        pictureBox.Image = mainImage;
+                    }
+                    control = pictureBox;
+                    break;
+                case LayoutControlType.WebBrowser:
+                    Panel browserPlaceholder = new Panel();
+                    browserPlaceholder.BackColor = Color.WhiteSmoke;
+                    browserPlaceholder.BorderStyle = BorderStyle.FixedSingle;
+                    Label placeholderLabel = new Label();
+                    placeholderLabel.Text = "WebBrowser";
+                    placeholderLabel.AutoSize = true;
+                    placeholderLabel.BackColor = Color.Transparent;
+                    placeholderLabel.Location = new Point(6, 6);
+                    browserPlaceholder.Controls.Add(placeholderLabel);
+                    control = browserPlaceholder;
+                    break;
+                case LayoutControlType.Panel:
+                    Panel panel = new Panel();
+                    panel.BackColor = Color.FromArgb(64, Color.Black);
+                    control = panel;
+                    break;
+                default:
+                    Panel placeholder = new Panel();
+                    placeholder.BackColor = Color.Gray;
+                    control = placeholder;
+                    break;
+            }
+
+            if (control == null)
+            {
+                return null;
+            }
+
+            control.Name = definition.Name;
+            control.Location = definition.Location;
+            if (!definition.AutoSize.HasValue || !definition.AutoSize.Value)
+            {
+                control.Size = definition.Size;
+            }
+
+            if (definition.Visible.HasValue)
+            {
+                control.Visible = definition.Visible.Value;
+            }
+
+            if (definition.Enabled.HasValue)
+            {
+                control.Enabled = definition.Enabled.Value;
+            }
+
+            if (definition.ForeColor.HasValue)
+            {
+                control.ForeColor = definition.ForeColor.Value;
+            }
+
+            if (definition.BackColor.HasValue)
+            {
+                control.BackColor = definition.BackColor.Value;
+            }
+            else if (definition.BackColor == null && definition.Type == LayoutControlType.Label)
+            {
+                control.BackColor = Color.Transparent;
+            }
+
+            if (definition.Font != null)
+            {
+                try
+                {
+                    control.Font = definition.Font.ToFont();
+                }
+                catch
+                {
+                }
+            }
+
+            return control;
+        }
+
+        private Control CreateDynamicButtonVisual(DynamicButtonDefinition definition)
+        {
+            PictureBox pictureBox = new PictureBox();
+            pictureBox.Name = definition.Name;
+            pictureBox.Location = definition.Location;
+            pictureBox.Size = definition.Size;
+            pictureBox.SizeMode = definition.SizeMode.HasValue ? definition.SizeMode.Value : PictureBoxSizeMode.StretchImage;
+            pictureBox.BackgroundImageLayout = ParseImageLayout(definition.BackgroundLayout);
+            pictureBox.Visible = definition.Visible;
+            pictureBox.Enabled = definition.Enabled;
+
+            SkinVisualState initialState = SkinVisualState.Normal;
+            Image image = this.GetSkinImage(definition.Visuals, initialState);
+            if (image == null)
+            {
+                image = this.GetSkinImage(definition.Visuals, SkinVisualState.Hover);
+            }
+            if (image == null)
+            {
+                image = this.GetSkinImage(definition.Visuals, SkinVisualState.Pressed);
+            }
+            if (image != null)
+            {
+                pictureBox.BackgroundImage = image;
+            }
+
+            return pictureBox;
+        }
+
+        private Image GetSkinImage(ButtonVisuals visuals, SkinVisualState state)
+        {
+            string path = null;
+            switch (state)
+            {
+                case SkinVisualState.Normal:
+                    path = visuals.Normal;
+                    break;
+                case SkinVisualState.Hover:
+                    path = visuals.Hover;
+                    break;
+                case SkinVisualState.Pressed:
+                    path = visuals.Pressed;
+                    break;
+                case SkinVisualState.Disabled:
+                    path = visuals.Disabled;
+                    break;
+                case SkinVisualState.Checked:
+                    path = visuals.Checked;
+                    break;
+                case SkinVisualState.Unchecked:
+                    path = visuals.Unchecked;
+                    break;
+                case SkinVisualState.Blink:
+                    path = visuals.Blink;
+                    break;
+            }
+
+            if (string.IsNullOrEmpty(path))
+            {
+                return null;
+            }
+
+            string resolved = this.ResolveAssetPath(path);
+            return this.LoadImageCopy(resolved);
+        }
+
+        private void EnsureSelectionOverlay()
+        {
+            if (this.selectionOverlay == null)
+            {
+                this.selectionOverlay = new Panel();
+                this.selectionOverlay.BorderStyle = BorderStyle.FixedSingle;
+                this.selectionOverlay.BackColor = Color.Transparent;
+                this.selectionOverlay.Enabled = false;
+            }
+
+            if (this.layoutSurface != null && this.selectionOverlay.Parent != this.layoutSurface)
+            {
+                this.layoutSurface.Controls.Add(this.selectionOverlay);
+                this.selectionOverlay.Visible = false;
+            }
+        }
+
+        private void UpdateSelection(Control control, object definition)
+        {
+            if (definition is FormLayout)
+            {
+                definition = null;
+            }
+
+            this.selectedControl = control;
+            this.selectedDefinition = definition;
+            this.UpdateSelectionOverlay();
+
+            string assetBase = this.GetAssetBaseDirectory();
+            RelativePathEditor.BaseDirectory = assetBase;
+
+            if (definition == null)
+            {
+                this.propertyGrid1.SelectedObject = new FormProperties(this.currentLayout, assetBase);
+            }
+            else if (definition is DynamicButtonDefinition)
+            {
+                DynamicButtonDefinition dynamicDefinition = (DynamicButtonDefinition)definition;
+                this.propertyGrid1.SelectedObject = new DynamicButtonProperties(dynamicDefinition, assetBase);
+            }
+            else if (definition is LayoutControl)
+            {
+                LayoutControl layoutControl = (LayoutControl)definition;
+                this.propertyGrid1.SelectedObject = new LayoutControlProperties(layoutControl, assetBase);
+            }
+
+            this.UpdateStatusLabel();
+        }
+
+        private void UpdateSelectionOverlay()
+        {
+            if (this.selectionOverlay == null || this.layoutSurface == null)
+            {
+                return;
+            }
+
+            if (this.selectedControl == null)
+            {
+                this.selectionOverlay.Visible = false;
+                return;
+            }
+
+            this.selectionOverlay.Bounds = this.selectedControl.Bounds;
+            this.selectionOverlay.Visible = true;
+            this.selectionOverlay.BringToFront();
+        }
+
+        private void MarkDirty()
+        {
+            this.isDirty = true;
+            this.UpdateWindowTitle();
+            this.UpdateStatusLabel();
+        }
+
+        private void UpdateWindowTitle()
+        {
+            string name = this.currentLayout != null ? this.currentLayout.SourcePath : null;
+            if (string.IsNullOrEmpty(name))
+            {
+                name = "New Layout";
+            }
+            else
+            {
+                name = Path.GetFileName(name);
+            }
+            if (this.isDirty)
+            {
+                name += "*";
+            }
+            this.Text = "Layout Editor - " + name;
+        }
+
+        private void UpdateStatusLabel()
+        {
+            string path = this.currentLayout != null ? this.currentLayout.SourcePath : null;
+            if (string.IsNullOrEmpty(path))
+            {
+                path = "(unsaved layout)";
+            }
+
+            string assets = this.GetAssetBaseDirectory();
+            if (string.IsNullOrEmpty(assets))
+            {
+                assets = "(assets not set)";
+            }
+
+            string suffix = this.isDirty ? "*" : string.Empty;
+            this.statusLabelPath.Text = "Layout: " + path + suffix + " | Assets: " + assets;
+        }
+
+        private string GetInitialLayoutDirectory()
+        {
+            string path = this.currentLayout != null ? this.currentLayout.SourcePath : null;
+            if (!string.IsNullOrEmpty(path) && Directory.Exists(Path.GetDirectoryName(path)))
+            {
+                return Path.GetDirectoryName(path);
+            }
+
+            string folder = this.GetLayoutDirectory();
+            if (!string.IsNullOrEmpty(folder))
+            {
+                return folder;
+            }
+
+            return Environment.CurrentDirectory;
+        }
+
+        private string GetLayoutDirectory()
+        {
+            if (this.currentLayout == null || string.IsNullOrEmpty(this.currentLayout.SourcePath))
+            {
+                return Environment.CurrentDirectory;
+            }
+            return Path.GetDirectoryName(this.currentLayout.SourcePath);
+        }
+
+        private string GetAssetBaseDirectory()
+        {
+            if (this.currentLayout == null)
+            {
+                return null;
+            }
+
+            string baseName = this.currentLayout.AssetDirectoryName;
+            if (string.IsNullOrEmpty(baseName))
+            {
+                return this.GetLayoutDirectory();
+            }
+
+            string layoutDir = this.GetLayoutDirectory();
+            if (string.IsNullOrEmpty(baseName))
+            {
+                return layoutDir;
+            }
+
+            if (Path.IsPathRooted(baseName))
+            {
+                return baseName;
+            }
+
+            if (string.IsNullOrEmpty(layoutDir))
+            {
+                return baseName;
+            }
+
+            string combined = Path.Combine(layoutDir, baseName);
+            return Path.GetFullPath(combined);
+        }
+
+        private void DisposeLoadedImages()
+        {
+            foreach (Image image in this.loadedImages)
+            {
+                if (image != null)
+                {
+                    image.Dispose();
+                }
+            }
+            this.loadedImages.Clear();
+        }
+
+        private Image LoadImageCopy(string path)
+        {
+            if (string.IsNullOrEmpty(path) || !File.Exists(path))
+            {
+                return null;
+            }
+
+            try
+            {
+                using (Image original = Image.FromFile(path))
+                {
+                    Bitmap copy = new Bitmap(original);
+                    this.loadedImages.Add(copy);
+                    return copy;
+                }
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        internal static ImageLayout ParseImageLayout(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return ImageLayout.None;
+            }
+
+            try
+            {
+                return (ImageLayout)Enum.Parse(typeof(ImageLayout), value, true);
+            }
+            catch
+            {
+                return ImageLayout.None;
+            }
+        }
+
+        private string ResolveAssetPath(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return null;
+            }
+
+            string path = value.Replace('/', Path.DirectorySeparatorChar);
+            if (Path.IsPathRooted(path))
+            {
+                return path;
+            }
+
+            string baseDir = this.GetAssetBaseDirectory();
+            if (string.IsNullOrEmpty(baseDir))
+            {
+                return path;
+            }
+
+            return Path.Combine(baseDir, path);
+        }
+
+        private static string NormalizeAssetPath(string path)
+        {
+            if (string.IsNullOrEmpty(path))
+            {
+                return path;
+            }
+
+            return path.Replace('\', '/');
+        }
+
+        private static string MakeRelativePath(string baseDirectory, string targetPath)
+        {
+            if (string.IsNullOrEmpty(baseDirectory))
+            {
+                return targetPath ?? string.Empty;
+            }
+
+            try
+            {
+                string baseDir = baseDirectory;
+                if (!baseDir.EndsWith(Path.DirectorySeparatorChar.ToString()))
+                {
+                    baseDir += Path.DirectorySeparatorChar;
+                }
+                Uri baseUri = new Uri(baseDir);
+                Uri targetUri = new Uri(targetPath);
+                Uri relativeUri = baseUri.MakeRelativeUri(targetUri);
+                string relative = Uri.UnescapeDataString(relativeUri.ToString());
+                return NormalizeAssetPath(relative);
+            }
+            catch
+            {
+                return targetPath ?? string.Empty;
+            }
+        }
+
+        private string GenerateDynamicButtonName()
+        {
+            int counter = 1;
+            string name;
+            while (true)
+            {
+                name = "DynamicButton" + counter;
+                bool exists = false;
+                foreach (DynamicButtonDefinition existing in this.currentLayout.DynamicButtons)
+                {
+                    if (string.Equals(existing.Name, name, StringComparison.OrdinalIgnoreCase))
+                    {
+                        exists = true;
+                        break;
+                    }
+                }
+
+                if (!exists)
+                {
+                    return name;
+                }
+
+                counter++;
+            }
+        }
+    }
+}

--- a/Launcher.LayoutEditor/Program.cs
+++ b/Launcher.LayoutEditor/Program.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Windows.Forms;
+
+namespace Launcher.LayoutEditor
+{
+    internal static class Program
+    {
+        [STAThread]
+        private static void Main()
+        {
+            Application.EnableVisualStyles();
+            Application.SetCompatibleTextRenderingDefault(false);
+            Application.Run(new MainForm());
+        }
+    }
+}

--- a/Launcher.LayoutEditor/Properties/AssemblyInfo.cs
+++ b/Launcher.LayoutEditor/Properties/AssemblyInfo.cs
@@ -1,0 +1,17 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("Launcher Layout Editor")]
+[assembly: AssemblyDescription("Visual editor for launcher layout files")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Launcher")]
+[assembly: AssemblyProduct("Launcher Layout Editor")]
+[assembly: AssemblyCopyright("Copyright © Launcher")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+

--- a/Launcher.LayoutEditor/PropertyModels.cs
+++ b/Launcher.LayoutEditor/PropertyModels.cs
@@ -1,0 +1,475 @@
+using System;
+using System.ComponentModel;
+using System.Drawing;
+using System.Windows.Forms;
+using Launcher.Layout;
+
+namespace Launcher.LayoutEditor
+{
+    internal interface IPropertyModel
+    {
+        object Underlying { get; }
+
+        void OnPropertyChanged();
+    }
+
+    public class FormProperties : IPropertyModel
+    {
+        private readonly LayoutDefinition layout;
+        private readonly string assetBaseDirectory;
+
+        public FormProperties(LayoutDefinition layout, string assetBaseDirectory)
+        {
+            this.layout = layout;
+            this.assetBaseDirectory = assetBaseDirectory;
+            if (this.layout.Form == null)
+            {
+                this.layout.Form = new FormLayout();
+            }
+        }
+
+        [Category("Layout"), DisplayName("Client Size"), Description("Dimensions of the launcher window.")]
+        public Size ClientSize
+        {
+            get
+            {
+                return this.layout.Form.ClientSize.IsEmpty ? new Size(960, 540) : this.layout.Form.ClientSize;
+            }
+            set
+            {
+                this.layout.Form.ClientSize = value;
+            }
+        }
+
+        [Category("Appearance"), DisplayName("Caption"), Description("Window title caption.")]
+        public string Caption
+        {
+            get { return this.layout.Form.Caption; }
+            set { this.layout.Form.Caption = value; }
+        }
+
+        [Category("Appearance"), DisplayName("Background Image"), Description("Form background image."), Editor(typeof(RelativePathEditor), typeof(System.Drawing.Design.UITypeEditor))]
+        public string BackgroundImage
+        {
+            get { return this.layout.Form.BackgroundImage; }
+            set { this.layout.Form.BackgroundImage = NormalizePath(value); }
+        }
+
+        [Category("Appearance"), DisplayName("Icon"), Description("Application icon."), Editor(typeof(RelativePathEditor), typeof(System.Drawing.Design.UITypeEditor))]
+        public string Icon
+        {
+            get { return this.layout.Form.Icon; }
+            set { this.layout.Form.Icon = NormalizePath(value); }
+        }
+
+        [Category("Appearance"), DisplayName("Transparency Key"), Description("Color treated as transparent. Use Empty to disable."), DefaultValue(typeof(Color), "")]
+        public Color TransparencyKey
+        {
+            get
+            {
+                return this.layout.Form.TransparencyKey.HasValue ? this.layout.Form.TransparencyKey.Value : Color.Empty;
+            }
+            set
+            {
+                if (value.IsEmpty)
+                {
+                    this.layout.Form.TransparencyKey = null;
+                }
+                else
+                {
+                    this.layout.Form.TransparencyKey = value;
+                }
+            }
+        }
+
+        [Category("Appearance"), DisplayName("Show Icon"), Description("Determines if the window shows an icon."), DefaultValue(true)]
+        public bool ShowIcon
+        {
+            get
+            {
+                if (!this.layout.Form.ShowIcon.HasValue)
+                {
+                    return true;
+                }
+                return this.layout.Form.ShowIcon.Value;
+            }
+            set { this.layout.Form.ShowIcon = value; }
+        }
+
+        [Category("Assets"), DisplayName("Asset Folder"), Description("Base folder used for asset lookups."), ReadOnly(true)]
+        public string AssetFolder
+        {
+            get
+            {
+                return this.layout.AssetDirectoryName;
+            }
+        }
+
+        public object Underlying
+        {
+            get { return this.layout.Form; }
+        }
+
+        public void OnPropertyChanged()
+        {
+        }
+
+        private string NormalizePath(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return value;
+            }
+
+            return RelativePathEditor.NormalizeRelative(value, this.assetBaseDirectory);
+        }
+    }
+
+    public class LayoutControlProperties : IPropertyModel
+    {
+        private readonly LayoutControl control;
+        private readonly string assetBaseDirectory;
+
+        public LayoutControlProperties(LayoutControl control, string assetBaseDirectory)
+        {
+            this.control = control;
+            this.assetBaseDirectory = assetBaseDirectory;
+        }
+
+        [Category("General"), DisplayName("Name")]
+        public string Name
+        {
+            get { return this.control.Name; }
+            set { this.control.Name = value; }
+        }
+
+        [Category("General"), DisplayName("Type"), ReadOnly(true)]
+        public LayoutControlType Type
+        {
+            get { return this.control.Type; }
+        }
+
+        [Category("Layout"), DisplayName("Location")]
+        public Point Location
+        {
+            get { return this.control.Location; }
+            set { this.control.Location = value; }
+        }
+
+        [Category("Layout"), DisplayName("Size")]
+        public Size Size
+        {
+            get { return this.control.Size; }
+            set { this.control.Size = value; }
+        }
+
+        [Category("Behavior"), DisplayName("Visible"), DefaultValue(true)]
+        public bool Visible
+        {
+            get
+            {
+                if (!this.control.Visible.HasValue)
+                {
+                    return true;
+                }
+                return this.control.Visible.Value;
+            }
+            set { this.control.Visible = value; }
+        }
+
+        [Category("Behavior"), DisplayName("Enabled"), DefaultValue(true)]
+        public bool Enabled
+        {
+            get
+            {
+                if (!this.control.Enabled.HasValue)
+                {
+                    return true;
+                }
+                return this.control.Enabled.Value;
+            }
+            set { this.control.Enabled = value; }
+        }
+
+        [Category("Behavior"), DisplayName("Auto Size"), DefaultValue(false)]
+        public bool AutoSize
+        {
+            get
+            {
+                if (!this.control.AutoSize.HasValue)
+                {
+                    return false;
+                }
+                return this.control.AutoSize.Value;
+            }
+            set { this.control.AutoSize = value; }
+        }
+
+        [Category("Appearance"), DisplayName("Text")]
+        public string Text
+        {
+            get { return this.control.Text; }
+            set { this.control.Text = value; }
+        }
+
+        [Category("Appearance"), DisplayName("Fore Color"), DefaultValue(typeof(Color), "")]
+        public Color ForeColor
+        {
+            get { return this.control.ForeColor.HasValue ? this.control.ForeColor.Value : Color.Empty; }
+            set { this.control.ForeColor = value.IsEmpty ? (Color?)null : value; }
+        }
+
+        [Category("Appearance"), DisplayName("Back Color"), DefaultValue(typeof(Color), "")]
+        public Color BackColor
+        {
+            get { return this.control.BackColor.HasValue ? this.control.BackColor.Value : Color.Empty; }
+            set { this.control.BackColor = value.IsEmpty ? (Color?)null : value; }
+        }
+
+        [Category("Appearance"), DisplayName("Font")]
+        public Font Font
+        {
+            get
+            {
+                if (this.control.Font == null)
+                {
+                    return SystemFonts.DefaultFont;
+                }
+                try
+                {
+                    return this.control.Font.ToFont();
+                }
+                catch
+                {
+                    return SystemFonts.DefaultFont;
+                }
+            }
+            set
+            {
+                if (value == null)
+                {
+                    this.control.Font = null;
+                }
+                else
+                {
+                    this.control.Font = FontLayout.FromFont(value);
+                }
+            }
+        }
+
+        [Category("Appearance"), DisplayName("Background Image"), Editor(typeof(RelativePathEditor), typeof(System.Drawing.Design.UITypeEditor))]
+        public string BackgroundImage
+        {
+            get { return this.control.BackgroundImage; }
+            set { this.control.BackgroundImage = NormalizePath(value); }
+        }
+
+        [Category("Appearance"), DisplayName("Image"), Editor(typeof(RelativePathEditor), typeof(System.Drawing.Design.UITypeEditor))]
+        public string Image
+        {
+            get { return this.control.Image; }
+            set { this.control.Image = NormalizePath(value); }
+        }
+
+        [Category("Appearance"), DisplayName("Text Align"), DefaultValue(typeof(ContentAlignment), "TopLeft")]
+        public ContentAlignment TextAlign
+        {
+            get { return this.control.TextAlign.HasValue ? this.control.TextAlign.Value : ContentAlignment.TopLeft; }
+            set { this.control.TextAlign = value; }
+        }
+
+        [Category("Appearance"), DisplayName("Size Mode"), DefaultValue(typeof(PictureBoxSizeMode), "Normal")]
+        public PictureBoxSizeMode SizeMode
+        {
+            get { return this.control.SizeMode.HasValue ? this.control.SizeMode.Value : PictureBoxSizeMode.Normal; }
+            set { this.control.SizeMode = value; }
+        }
+
+        [Category("Behavior"), DisplayName("URL")]
+        public string Url
+        {
+            get { return this.control.Url; }
+            set { this.control.Url = value; }
+        }
+
+        [Category("Behavior"), DisplayName("Cursor")]
+        public string Cursor
+        {
+            get { return this.control.Cursor; }
+            set { this.control.Cursor = value; }
+        }
+
+        [Category("Appearance"), DisplayName("Background Layout"), DefaultValue(typeof(ImageLayout), "None")]
+        public ImageLayout BackgroundLayout
+        {
+            get { return MainForm.ParseImageLayout(this.control.BackgroundLayout); }
+            set { this.control.BackgroundLayout = value.ToString(); }
+        }
+
+        public object Underlying
+        {
+            get { return this.control; }
+        }
+
+        public void OnPropertyChanged()
+        {
+        }
+
+        private string NormalizePath(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return value;
+            }
+
+            return RelativePathEditor.NormalizeRelative(value, this.assetBaseDirectory);
+        }
+    }
+
+    public class DynamicButtonProperties : IPropertyModel
+    {
+        private readonly DynamicButtonDefinition button;
+        private readonly string assetBaseDirectory;
+
+        public DynamicButtonProperties(DynamicButtonDefinition button, string assetBaseDirectory)
+        {
+            this.button = button;
+            this.assetBaseDirectory = assetBaseDirectory;
+        }
+
+        [Category("General"), DisplayName("Name")]
+        public string Name
+        {
+            get { return this.button.Name; }
+            set
+            {
+                this.button.Name = value;
+                this.button.Target = value;
+            }
+        }
+
+        [Category("Layout"), DisplayName("Location")]
+        public Point Location
+        {
+            get { return this.button.Location; }
+            set { this.button.Location = value; }
+        }
+
+        [Category("Layout"), DisplayName("Size")]
+        public Size Size
+        {
+            get { return this.button.Size; }
+            set { this.button.Size = value; }
+        }
+
+        [Category("Behavior"), DisplayName("Action")]
+        public string Action
+        {
+            get { return this.button.Action; }
+            set { this.button.Action = value; }
+        }
+
+        [Category("Behavior"), DisplayName("Argument")]
+        public string Argument
+        {
+            get { return this.button.Argument; }
+            set { this.button.Argument = value; }
+        }
+
+        [Category("Behavior"), DisplayName("Visible"), DefaultValue(true)]
+        public bool Visible
+        {
+            get { return this.button.Visible; }
+            set { this.button.Visible = value; }
+        }
+
+        [Category("Behavior"), DisplayName("Enabled"), DefaultValue(true)]
+        public bool Enabled
+        {
+            get { return this.button.Enabled; }
+            set { this.button.Enabled = value; }
+        }
+
+        [Category("Appearance"), DisplayName("Size Mode"), DefaultValue(typeof(PictureBoxSizeMode), "StretchImage")]
+        public PictureBoxSizeMode SizeMode
+        {
+            get { return this.button.SizeMode.HasValue ? this.button.SizeMode.Value : PictureBoxSizeMode.StretchImage; }
+            set { this.button.SizeMode = value; }
+        }
+
+        [Category("Appearance"), DisplayName("Background Layout"), DefaultValue(typeof(ImageLayout), "None")]
+        public ImageLayout BackgroundLayout
+        {
+            get { return MainForm.ParseImageLayout(this.button.BackgroundLayout); }
+            set { this.button.BackgroundLayout = value.ToString(); }
+        }
+
+        [Category("Visuals"), DisplayName("Normal"), Editor(typeof(RelativePathEditor), typeof(System.Drawing.Design.UITypeEditor))]
+        public string Normal
+        {
+            get { return this.button.Visuals.Normal; }
+            set { this.button.Visuals.Normal = NormalizePath(value); }
+        }
+
+        [Category("Visuals"), DisplayName("Hover"), Editor(typeof(RelativePathEditor), typeof(System.Drawing.Design.UITypeEditor))]
+        public string Hover
+        {
+            get { return this.button.Visuals.Hover; }
+            set { this.button.Visuals.Hover = NormalizePath(value); }
+        }
+
+        [Category("Visuals"), DisplayName("Pressed"), Editor(typeof(RelativePathEditor), typeof(System.Drawing.Design.UITypeEditor))]
+        public string Pressed
+        {
+            get { return this.button.Visuals.Pressed; }
+            set { this.button.Visuals.Pressed = NormalizePath(value); }
+        }
+
+        [Category("Visuals"), DisplayName("Disabled"), Editor(typeof(RelativePathEditor), typeof(System.Drawing.Design.UITypeEditor))]
+        public string Disabled
+        {
+            get { return this.button.Visuals.Disabled; }
+            set { this.button.Visuals.Disabled = NormalizePath(value); }
+        }
+
+        [Category("Visuals"), DisplayName("Checked"), Editor(typeof(RelativePathEditor), typeof(System.Drawing.Design.UITypeEditor))]
+        public string Checked
+        {
+            get { return this.button.Visuals.Checked; }
+            set { this.button.Visuals.Checked = NormalizePath(value); }
+        }
+
+        [Category("Visuals"), DisplayName("Unchecked"), Editor(typeof(RelativePathEditor), typeof(System.Drawing.Design.UITypeEditor))]
+        public string Unchecked
+        {
+            get { return this.button.Visuals.Unchecked; }
+            set { this.button.Visuals.Unchecked = NormalizePath(value); }
+        }
+
+        [Category("Visuals"), DisplayName("Blink"), Editor(typeof(RelativePathEditor), typeof(System.Drawing.Design.UITypeEditor))]
+        public string Blink
+        {
+            get { return this.button.Visuals.Blink; }
+            set { this.button.Visuals.Blink = NormalizePath(value); }
+        }
+
+        public object Underlying
+        {
+            get { return this.button; }
+        }
+
+        public void OnPropertyChanged()
+        {
+        }
+
+        private string NormalizePath(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return value;
+            }
+
+            return RelativePathEditor.NormalizeRelative(value, this.assetBaseDirectory);
+        }
+    }
+}

--- a/Launcher.LayoutEditor/RelativePathEditor.cs
+++ b/Launcher.LayoutEditor/RelativePathEditor.cs
@@ -1,0 +1,120 @@
+using System;
+using System.ComponentModel;
+using System.Drawing.Design;
+using System.IO;
+using System.Windows.Forms;
+
+namespace Launcher.LayoutEditor
+{
+    public class RelativePathEditor : UITypeEditor
+    {
+        public static string BaseDirectory;
+
+        public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext context)
+        {
+            return UITypeEditorEditStyle.Modal;
+        }
+
+        public override object EditValue(ITypeDescriptorContext context, IServiceProvider provider, object value)
+        {
+            string currentValue = value as string;
+            using (OpenFileDialog dialog = new OpenFileDialog())
+            {
+                dialog.Filter = "All files (*.*)|*.*";
+                dialog.Title = "Select file";
+                string baseDirectory = BaseDirectory;
+                if (!string.IsNullOrEmpty(baseDirectory) && Directory.Exists(baseDirectory))
+                {
+                    dialog.InitialDirectory = baseDirectory;
+                }
+
+                string absoluteCurrent = ResolveAbsolutePath(currentValue, baseDirectory);
+                if (!string.IsNullOrEmpty(absoluteCurrent) && File.Exists(absoluteCurrent))
+                {
+                    dialog.FileName = absoluteCurrent;
+                }
+
+                if (dialog.ShowDialog() == DialogResult.OK)
+                {
+                    return MakeRelative(dialog.FileName, baseDirectory);
+                }
+            }
+
+            return value;
+        }
+
+        public static string NormalizeRelative(string path, string baseDirectory)
+        {
+            if (string.IsNullOrEmpty(path))
+            {
+                return path;
+            }
+
+            if (Path.IsPathRooted(path))
+            {
+                if (!string.IsNullOrEmpty(baseDirectory))
+                {
+                    return MakeRelative(path, baseDirectory);
+                }
+                return path;
+            }
+
+            return path.Replace('\', '/');
+        }
+
+        private static string ResolveAbsolutePath(string value, string baseDirectory)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return null;
+            }
+
+            string path = value;
+            if (!Path.IsPathRooted(path))
+            {
+                if (!string.IsNullOrEmpty(baseDirectory))
+                {
+                    path = Path.Combine(baseDirectory, value.Replace('/', Path.DirectorySeparatorChar));
+                }
+                else
+                {
+                    path = Path.Combine(Environment.CurrentDirectory, value.Replace('/', Path.DirectorySeparatorChar));
+                }
+            }
+
+            return path;
+        }
+
+        private static string MakeRelative(string absolutePath, string baseDirectory)
+        {
+            if (string.IsNullOrEmpty(absolutePath))
+            {
+                return absolutePath;
+            }
+
+            if (string.IsNullOrEmpty(baseDirectory))
+            {
+                return absolutePath;
+            }
+
+            try
+            {
+                string baseDir = baseDirectory;
+                if (!baseDir.EndsWith(Path.DirectorySeparatorChar.ToString()))
+                {
+                    baseDir += Path.DirectorySeparatorChar;
+                }
+
+                Uri baseUri = new Uri(baseDir);
+                Uri fileUri = new Uri(absolutePath);
+                string relative = baseUri.MakeRelativeUri(fileUri).ToString();
+                relative = Uri.UnescapeDataString(relative);
+                return relative.Replace('\', '/');
+            }
+            catch
+            {
+                return absolutePath;
+            }
+        }
+    }
+}

--- a/Launcher.sln
+++ b/Launcher.sln
@@ -3,6 +3,8 @@ Microsoft Visual Studio Solution File, Format Version 11.00
 # Visual Studio 2010
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Launcher", "Launcher\Launcher.csproj", "{7EC0DECB-3B30-4B20-B7A3-C1CE99AF2C85}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Launcher.LayoutEditor", "Launcher.LayoutEditor\Launcher.LayoutEditor.csproj", "{8F30A00D-1C72-4B70-AB6A-4D89CE801C64}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -13,6 +15,10 @@ Global
 		{7EC0DECB-3B30-4B20-B7A3-C1CE99AF2C85}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7EC0DECB-3B30-4B20-B7A3-C1CE99AF2C85}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7EC0DECB-3B30-4B20-B7A3-C1CE99AF2C85}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8F30A00D-1C72-4B70-AB6A-4D89CE801C64}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8F30A00D-1C72-4B70-AB6A-4D89CE801C64}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8F30A00D-1C72-4B70-AB6A-4D89CE801C64}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8F30A00D-1C72-4B70-AB6A-4D89CE801C64}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Launcher/Exile/Common.cs
+++ b/Launcher/Exile/Common.cs
@@ -11,6 +11,7 @@ using System.Drawing.Drawing2D;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
+using Launcher.Layout;
 
 namespace Launcher.Exile
 {
@@ -68,6 +69,11 @@ namespace Launcher.Exile
             Globals.pForm.pictureBox4.Enabled = true;
             Globals.pForm.pictureBox1.Cursor = Cursors.Hand;
             Globals.EnableStartBTN = true;
+            if (Globals.LayoutContext != null)
+            {
+                Globals.LayoutContext.SetState("pictureBox1", SkinVisualState.Normal);
+                Globals.LayoutContext.SetState("pictureBox3", SkinVisualState.Normal);
+            }
         }
 
         public static Image ResizeImage(Image source, int Width, int Height, int dx, int dy)

--- a/Launcher/Exile/FileDownloader.cs
+++ b/Launcher/Exile/FileDownloader.cs
@@ -4,6 +4,7 @@
 // MVID: D4AA755B-F045-4A12-838C-6A7934E8D46E
 // Assembly location: D:\NDev\NNTeam\nDev\launcher\Net 4.0\Launcher.exe
 
+using Launcher.Layout;
 using Launcher.Properties;
 using System;
 using System.ComponentModel;
@@ -26,13 +27,19 @@ namespace Launcher.Exile
             if (Globals.OldFiles.Count <= 0)
             {
                 Common.ChangeStatus("CHECKCOMPLETE");
-                Globals.pForm.pictureBox1.BackgroundImage = (Image)Resources.start_1;
+                if (Globals.LayoutContext == null || !Globals.LayoutContext.SetState("pictureBox1", SkinVisualState.Normal))
+                {
+                    Globals.pForm.pictureBox1.BackgroundImage = (Image)Resources.start_1;
+                }
                 Common.EnableStart();
             }
             else if (FileDownloader.curFile >= Globals.OldFiles.Count)
             {
                 Common.ChangeStatus("DOWNLOADCOMPLETE");
-                Globals.pForm.pictureBox1.BackgroundImage = (Image)Resources.start_1;
+                if (Globals.LayoutContext == null || !Globals.LayoutContext.SetState("pictureBox1", SkinVisualState.Normal))
+                {
+                    Globals.pForm.pictureBox1.BackgroundImage = (Image)Resources.start_1;
+                }
                 Common.EnableStart();
             }
             else

--- a/Launcher/Exile/Globals.cs
+++ b/Launcher/Exile/Globals.cs
@@ -5,6 +5,7 @@
 // Assembly location: D:\NDev\NNTeam\nDev\launcher\Net 4.0\Launcher.exe
 
 using System.Collections.Generic;
+using Launcher.Layout;
 
 namespace Launcher.Exile
 {
@@ -19,6 +20,7 @@ namespace Launcher.Exile
         public static List<Globals.File> Files = new List<Globals.File>();
         public static List<string> OldFiles = new List<string>();
         public static pForm pForm;
+        public static LayoutRuntimeContext LayoutContext;
         public static long fullSize;
         public static long completeSize;
 

--- a/Launcher/Launcher.csproj
+++ b/Launcher/Launcher.csproj
@@ -72,6 +72,8 @@
     <Compile Include="IniParser\Parser\IniDataParser.cs" />
     <Compile Include="IniParser\StreamIniDataParser.cs" />
     <Compile Include="IniParser\StringIniParser.cs" />
+    <Compile Include="Layout\LayoutDefinition.cs" />
+    <Compile Include="Layout\LayoutRuntime.cs" />
     <Compile Include="Opcoes.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/Launcher/Layout/LayoutDefinition.cs
+++ b/Launcher/Layout/LayoutDefinition.cs
@@ -1,0 +1,764 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Globalization;
+using System.IO;
+using System.Xml;
+
+namespace Launcher.Layout
+{
+    public enum LayoutControlType
+    {
+        Unknown,
+        Label,
+        PictureBox,
+        WebBrowser,
+        Panel
+    }
+
+    public class LayoutDefinition
+    {
+        private string assetDirectoryName;
+        private string sourcePath;
+        private FormLayout form;
+        private readonly List<LayoutControl> controls;
+        private readonly List<ImageButtonDefinition> imageButtons;
+        private readonly List<DynamicButtonDefinition> dynamicButtons;
+
+        public LayoutDefinition()
+        {
+            this.controls = new List<LayoutControl>();
+            this.imageButtons = new List<ImageButtonDefinition>();
+            this.dynamicButtons = new List<DynamicButtonDefinition>();
+            this.form = new FormLayout();
+        }
+
+        public string AssetDirectoryName
+        {
+            get { return this.assetDirectoryName; }
+            set { this.assetDirectoryName = value; }
+        }
+
+        public string SourcePath
+        {
+            get { return this.sourcePath; }
+            set { this.sourcePath = value; }
+        }
+
+        public FormLayout Form
+        {
+            get { return this.form; }
+            set { this.form = value; }
+        }
+
+        public List<LayoutControl> Controls
+        {
+            get { return this.controls; }
+        }
+
+        public List<ImageButtonDefinition> ImageButtons
+        {
+            get { return this.imageButtons; }
+        }
+
+        public List<DynamicButtonDefinition> DynamicButtons
+        {
+            get { return this.dynamicButtons; }
+        }
+
+        public ImageButtonDefinition FindButtonByTarget(string target)
+        {
+            foreach (ImageButtonDefinition definition in this.imageButtons)
+            {
+                if (string.Equals(definition.Target, target, StringComparison.OrdinalIgnoreCase))
+                {
+                    return definition;
+                }
+            }
+
+            foreach (DynamicButtonDefinition definition2 in this.dynamicButtons)
+            {
+                if (string.Equals(definition2.Target, target, StringComparison.OrdinalIgnoreCase))
+                {
+                    return definition2;
+                }
+            }
+
+            return null;
+        }
+    }
+
+    public class FormLayout
+    {
+        public Size ClientSize = Size.Empty;
+        public string BackgroundImage;
+        public string Icon;
+        public Color? TransparencyKey;
+        public string Caption;
+        public bool? ShowIcon;
+    }
+
+    public class LayoutControl
+    {
+        public string Name;
+        public LayoutControlType Type = LayoutControlType.Unknown;
+        public Point Location = Point.Empty;
+        public Size Size = Size.Empty;
+        public bool? Visible;
+        public bool? Enabled;
+        public bool? AutoSize;
+        public string Text;
+        public Color? ForeColor;
+        public Color? BackColor;
+        public FontLayout Font;
+        public string BackgroundImage;
+        public string Image;
+        public ContentAlignment? TextAlign;
+        public PictureBoxSizeMode? SizeMode;
+        public string Url;
+        public string Cursor;
+        public string BackgroundLayout;
+    }
+
+    public class FontLayout
+    {
+        public string Family;
+        public float Size;
+        public FontStyle Style;
+
+        public static FontLayout FromFont(Font font)
+        {
+            FontLayout layout = new FontLayout();
+            layout.Family = font.FontFamily.Name;
+            layout.Size = font.Size;
+            layout.Style = font.Style;
+            return layout;
+        }
+
+        public Font ToFont()
+        {
+            if (this.Family == null || this.Family.Length == 0)
+            {
+                return SystemFonts.DefaultFont;
+            }
+
+            if (this.Size <= 0f)
+            {
+                return new Font(this.Family, SystemFonts.DefaultFont.Size, this.Style);
+            }
+
+            return new Font(this.Family, this.Size, this.Style);
+        }
+    }
+
+    public class ButtonVisuals
+    {
+        public string Normal;
+        public string Hover;
+        public string Pressed;
+        public string Disabled;
+        public string Checked;
+        public string Unchecked;
+        public string Blink;
+    }
+
+    public class ImageButtonDefinition
+    {
+        public string Target;
+        public ButtonVisuals Visuals = new ButtonVisuals();
+        public bool Blink;
+        public bool Checkable;
+    }
+
+    public class DynamicButtonDefinition : ImageButtonDefinition
+    {
+        public string Name;
+        public Point Location = Point.Empty;
+        public Size Size = Size.Empty;
+        public string Action;
+        public string Argument;
+        public bool Visible = true;
+        public bool Enabled = true;
+        public PictureBoxSizeMode? SizeMode;
+        public string BackgroundLayout;
+    }
+
+    public static class LayoutFile
+    {
+        public static LayoutDefinition Load(string path)
+        {
+            LayoutDefinition definition = new LayoutDefinition();
+            if (!File.Exists(path))
+            {
+                return definition;
+            }
+
+            definition.SourcePath = path;
+
+            XmlDocument document = new XmlDocument();
+            document.Load(path);
+            XmlElement root = document.DocumentElement;
+            if (root == null || root.Name != "layout")
+            {
+                return definition;
+            }
+
+            definition.AssetDirectoryName = GetAttribute(root, "basePath");
+
+            foreach (XmlNode node in root.ChildNodes)
+            {
+                if (node.NodeType != XmlNodeType.Element)
+                {
+                    continue;
+                }
+
+                switch (node.Name)
+                {
+                    case "form":
+                        definition.Form = ParseForm(node);
+                        break;
+                    case "control":
+                        definition.Controls.Add(ParseControl(node));
+                        break;
+                    case "imageButton":
+                        definition.ImageButtons.Add(ParseImageButton(node, false));
+                        break;
+                    case "toggleButton":
+                        ImageButtonDefinition toggle = ParseImageButton(node, true);
+                        toggle.Checkable = true;
+                        definition.ImageButtons.Add(toggle);
+                        break;
+                    case "dynamicButton":
+                        definition.DynamicButtons.Add(ParseDynamicButton(node));
+                        break;
+                }
+            }
+
+            return definition;
+        }
+
+        public static void Save(LayoutDefinition definition, string path)
+        {
+            XmlDocument document = new XmlDocument();
+            XmlElement root = document.CreateElement("layout");
+            if (!string.IsNullOrEmpty(definition.AssetDirectoryName))
+            {
+                root.SetAttribute("basePath", definition.AssetDirectoryName);
+            }
+            document.AppendChild(root);
+
+            AppendForm(document, root, definition.Form);
+
+            foreach (LayoutControl control in definition.Controls)
+            {
+                AppendControl(document, root, control);
+            }
+
+            foreach (ImageButtonDefinition button in definition.ImageButtons)
+            {
+                AppendImageButton(document, root, button, false);
+            }
+
+            foreach (DynamicButtonDefinition dynamicButton in definition.DynamicButtons)
+            {
+                AppendDynamicButton(document, root, dynamicButton);
+            }
+
+            Directory.CreateDirectory(Path.GetDirectoryName(path));
+            document.Save(path);
+            definition.SourcePath = path;
+        }
+
+        private static void AppendForm(XmlDocument document, XmlElement root, FormLayout form)
+        {
+            XmlElement element = document.CreateElement("form");
+            if (!form.ClientSize.IsEmpty)
+            {
+                element.SetAttribute("width", form.ClientSize.Width.ToString(CultureInfo.InvariantCulture));
+                element.SetAttribute("height", form.ClientSize.Height.ToString(CultureInfo.InvariantCulture));
+            }
+
+            if (!string.IsNullOrEmpty(form.BackgroundImage))
+            {
+                element.SetAttribute("background", form.BackgroundImage);
+            }
+
+            if (!string.IsNullOrEmpty(form.Icon))
+            {
+                element.SetAttribute("icon", form.Icon);
+            }
+
+            if (form.TransparencyKey.HasValue)
+            {
+                element.SetAttribute("transparency", ColorToString(form.TransparencyKey.Value));
+            }
+
+            if (!string.IsNullOrEmpty(form.Caption))
+            {
+                element.SetAttribute("caption", form.Caption);
+            }
+
+            if (form.ShowIcon.HasValue)
+            {
+                element.SetAttribute("showIcon", form.ShowIcon.Value ? "true" : "false");
+            }
+
+            root.AppendChild(element);
+        }
+
+        private static void AppendControl(XmlDocument document, XmlElement root, LayoutControl control)
+        {
+            XmlElement element = document.CreateElement("control");
+            element.SetAttribute("name", control.Name);
+            element.SetAttribute("type", control.Type.ToString());
+            element.SetAttribute("x", control.Location.X.ToString(CultureInfo.InvariantCulture));
+            element.SetAttribute("y", control.Location.Y.ToString(CultureInfo.InvariantCulture));
+            element.SetAttribute("width", control.Size.Width.ToString(CultureInfo.InvariantCulture));
+            element.SetAttribute("height", control.Size.Height.ToString(CultureInfo.InvariantCulture));
+
+            if (control.Visible.HasValue)
+            {
+                element.SetAttribute("visible", control.Visible.Value ? "true" : "false");
+            }
+
+            if (control.Enabled.HasValue)
+            {
+                element.SetAttribute("enabled", control.Enabled.Value ? "true" : "false");
+            }
+
+            if (control.AutoSize.HasValue)
+            {
+                element.SetAttribute("autoSize", control.AutoSize.Value ? "true" : "false");
+            }
+
+            if (!string.IsNullOrEmpty(control.Text))
+            {
+                element.SetAttribute("text", control.Text);
+            }
+
+            if (control.ForeColor.HasValue)
+            {
+                element.SetAttribute("foreColor", ColorToString(control.ForeColor.Value));
+            }
+
+            if (control.BackColor.HasValue)
+            {
+                element.SetAttribute("backColor", ColorToString(control.BackColor.Value));
+            }
+
+            if (control.Font != null)
+            {
+                element.SetAttribute("font", FontToString(control.Font));
+            }
+
+            if (!string.IsNullOrEmpty(control.BackgroundImage))
+            {
+                element.SetAttribute("background", control.BackgroundImage);
+            }
+
+            if (!string.IsNullOrEmpty(control.Image))
+            {
+                element.SetAttribute("image", control.Image);
+            }
+
+            if (control.TextAlign.HasValue)
+            {
+                element.SetAttribute("textAlign", control.TextAlign.Value.ToString());
+            }
+
+            if (control.SizeMode.HasValue)
+            {
+                element.SetAttribute("sizeMode", control.SizeMode.Value.ToString());
+            }
+
+            if (!string.IsNullOrEmpty(control.Url))
+            {
+                element.SetAttribute("url", control.Url);
+            }
+
+            if (!string.IsNullOrEmpty(control.Cursor))
+            {
+                element.SetAttribute("cursor", control.Cursor);
+            }
+
+            if (!string.IsNullOrEmpty(control.BackgroundLayout))
+            {
+                element.SetAttribute("backgroundLayout", control.BackgroundLayout);
+            }
+
+            root.AppendChild(element);
+        }
+
+        private static void AppendImageButton(XmlDocument document, XmlElement root, ImageButtonDefinition button, bool dynamic)
+        {
+            string nodeName = dynamic ? "dynamicButton" : (button.Checkable ? "toggleButton" : "imageButton");
+            XmlElement element = document.CreateElement(nodeName);
+            if (dynamic)
+            {
+                DynamicButtonDefinition dyn = (DynamicButtonDefinition)button;
+                element.SetAttribute("name", dyn.Name);
+                element.SetAttribute("x", dyn.Location.X.ToString(CultureInfo.InvariantCulture));
+                element.SetAttribute("y", dyn.Location.Y.ToString(CultureInfo.InvariantCulture));
+                element.SetAttribute("width", dyn.Size.Width.ToString(CultureInfo.InvariantCulture));
+                element.SetAttribute("height", dyn.Size.Height.ToString(CultureInfo.InvariantCulture));
+                if (!string.IsNullOrEmpty(dyn.Action))
+                {
+                    element.SetAttribute("action", dyn.Action);
+                }
+                if (!string.IsNullOrEmpty(dyn.Argument))
+                {
+                    element.SetAttribute("argument", dyn.Argument);
+                }
+                if (!dyn.Visible)
+                {
+                    element.SetAttribute("visible", "false");
+                }
+                if (!dyn.Enabled)
+                {
+                    element.SetAttribute("enabled", "false");
+                }
+                if (dyn.SizeMode.HasValue)
+                {
+                    element.SetAttribute("sizeMode", dyn.SizeMode.Value.ToString());
+                }
+                if (!string.IsNullOrEmpty(dyn.BackgroundLayout))
+                {
+                    element.SetAttribute("backgroundLayout", dyn.BackgroundLayout);
+                }
+            }
+            else
+            {
+                element.SetAttribute("target", button.Target);
+            }
+
+            if (!string.IsNullOrEmpty(button.Visuals.Normal))
+            {
+                element.SetAttribute("normal", button.Visuals.Normal);
+            }
+            if (!string.IsNullOrEmpty(button.Visuals.Hover))
+            {
+                element.SetAttribute("hover", button.Visuals.Hover);
+            }
+            if (!string.IsNullOrEmpty(button.Visuals.Pressed))
+            {
+                element.SetAttribute("pressed", button.Visuals.Pressed);
+            }
+            if (!string.IsNullOrEmpty(button.Visuals.Disabled))
+            {
+                element.SetAttribute("disabled", button.Visuals.Disabled);
+            }
+            if (!string.IsNullOrEmpty(button.Visuals.Checked))
+            {
+                element.SetAttribute("checked", button.Visuals.Checked);
+            }
+            if (!string.IsNullOrEmpty(button.Visuals.Unchecked))
+            {
+                element.SetAttribute("unchecked", button.Visuals.Unchecked);
+            }
+            if (!string.IsNullOrEmpty(button.Visuals.Blink))
+            {
+                element.SetAttribute("blink", button.Visuals.Blink);
+            }
+            if (button.Blink)
+            {
+                element.SetAttribute("useBlinkState", "true");
+            }
+
+            root.AppendChild(element);
+        }
+
+        private static void AppendDynamicButton(XmlDocument document, XmlElement root, DynamicButtonDefinition dynamicButton)
+        {
+            AppendImageButton(document, root, dynamicButton, true);
+        }
+
+        private static FormLayout ParseForm(XmlNode node)
+        {
+            FormLayout layout = new FormLayout();
+            layout.ClientSize = new Size(
+                ParseInt(GetAttribute(node, "width"), 0),
+                ParseInt(GetAttribute(node, "height"), 0));
+            layout.BackgroundImage = GetAttribute(node, "background");
+            layout.Icon = GetAttribute(node, "icon");
+            layout.TransparencyKey = ParseColor(GetAttribute(node, "transparency"));
+            layout.Caption = GetAttribute(node, "caption");
+            string showIcon = GetAttribute(node, "showIcon");
+            if (showIcon != null && showIcon.Length > 0)
+            {
+                layout.ShowIcon = ParseBool(showIcon);
+            }
+            return layout;
+        }
+
+        private static LayoutControl ParseControl(XmlNode node)
+        {
+            LayoutControl control = new LayoutControl();
+            control.Name = GetAttribute(node, "name");
+            control.Type = ParseControlType(GetAttribute(node, "type"));
+            control.Location = new Point(
+                ParseInt(GetAttribute(node, "x"), 0),
+                ParseInt(GetAttribute(node, "y"), 0));
+            control.Size = new Size(
+                ParseInt(GetAttribute(node, "width"), 0),
+                ParseInt(GetAttribute(node, "height"), 0));
+
+            string visible = GetAttribute(node, "visible");
+            if (visible != null && visible.Length > 0)
+            {
+                control.Visible = ParseBool(visible);
+            }
+
+            string enabled = GetAttribute(node, "enabled");
+            if (enabled != null && enabled.Length > 0)
+            {
+                control.Enabled = ParseBool(enabled);
+            }
+
+            string autoSize = GetAttribute(node, "autoSize");
+            if (autoSize != null && autoSize.Length > 0)
+            {
+                control.AutoSize = ParseBool(autoSize);
+            }
+
+            control.Text = GetAttribute(node, "text");
+            control.ForeColor = ParseColor(GetAttribute(node, "foreColor"));
+            control.BackColor = ParseColor(GetAttribute(node, "backColor"));
+            string font = GetAttribute(node, "font");
+            if (!string.IsNullOrEmpty(font))
+            {
+                control.Font = ParseFont(font);
+            }
+            control.BackgroundImage = GetAttribute(node, "background");
+            control.Image = GetAttribute(node, "image");
+            string textAlign = GetAttribute(node, "textAlign");
+            if (!string.IsNullOrEmpty(textAlign))
+            {
+                try
+                {
+                    control.TextAlign = (ContentAlignment)Enum.Parse(typeof(ContentAlignment), textAlign, true);
+                }
+                catch
+                {
+                }
+            }
+            string sizeMode = GetAttribute(node, "sizeMode");
+            if (!string.IsNullOrEmpty(sizeMode))
+            {
+                try
+                {
+                    control.SizeMode = (PictureBoxSizeMode)Enum.Parse(typeof(PictureBoxSizeMode), sizeMode, true);
+                }
+                catch
+                {
+                }
+            }
+            control.Url = GetAttribute(node, "url");
+            control.Cursor = GetAttribute(node, "cursor");
+            control.BackgroundLayout = GetAttribute(node, "backgroundLayout");
+            return control;
+        }
+
+        private static ImageButtonDefinition ParseImageButton(XmlNode node, bool toggle)
+        {
+            ImageButtonDefinition definition = new ImageButtonDefinition();
+            definition.Target = GetAttribute(node, "target");
+            definition.Blink = ParseBool(GetAttribute(node, "useBlinkState"));
+            definition.Checkable = toggle;
+            ButtonVisuals visuals = definition.Visuals;
+            visuals.Normal = GetAttribute(node, "normal");
+            visuals.Hover = GetAttribute(node, "hover");
+            visuals.Pressed = GetAttribute(node, "pressed");
+            visuals.Disabled = GetAttribute(node, "disabled");
+            visuals.Checked = GetAttribute(node, "checked");
+            visuals.Unchecked = GetAttribute(node, "unchecked");
+            visuals.Blink = GetAttribute(node, "blink");
+            return definition;
+        }
+
+        private static DynamicButtonDefinition ParseDynamicButton(XmlNode node)
+        {
+            DynamicButtonDefinition definition = new DynamicButtonDefinition();
+            definition.Name = GetAttribute(node, "name");
+            definition.Target = definition.Name;
+            definition.Location = new Point(
+                ParseInt(GetAttribute(node, "x"), 0),
+                ParseInt(GetAttribute(node, "y"), 0));
+            definition.Size = new Size(
+                ParseInt(GetAttribute(node, "width"), 0),
+                ParseInt(GetAttribute(node, "height"), 0));
+            definition.Action = GetAttribute(node, "action");
+            definition.Argument = GetAttribute(node, "argument");
+            string visible = GetAttribute(node, "visible");
+            if (visible != null && visible.Length > 0)
+            {
+                definition.Visible = ParseBool(visible);
+            }
+            string enabled = GetAttribute(node, "enabled");
+            if (enabled != null && enabled.Length > 0)
+            {
+                definition.Enabled = ParseBool(enabled);
+            }
+            string sizeMode = GetAttribute(node, "sizeMode");
+            if (!string.IsNullOrEmpty(sizeMode))
+            {
+                try
+                {
+                    definition.SizeMode = (PictureBoxSizeMode)Enum.Parse(typeof(PictureBoxSizeMode), sizeMode, true);
+                }
+                catch
+                {
+                }
+            }
+            definition.BackgroundLayout = GetAttribute(node, "backgroundLayout");
+
+            ButtonVisuals visuals = definition.Visuals;
+            visuals.Normal = GetAttribute(node, "normal");
+            visuals.Hover = GetAttribute(node, "hover");
+            visuals.Pressed = GetAttribute(node, "pressed");
+            visuals.Disabled = GetAttribute(node, "disabled");
+            visuals.Checked = GetAttribute(node, "checked");
+            visuals.Unchecked = GetAttribute(node, "unchecked");
+            visuals.Blink = GetAttribute(node, "blink");
+            return definition;
+        }
+
+        private static LayoutControlType ParseControlType(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return LayoutControlType.Unknown;
+            }
+
+            try
+            {
+                return (LayoutControlType)Enum.Parse(typeof(LayoutControlType), value, true);
+            }
+            catch
+            {
+                return LayoutControlType.Unknown;
+            }
+        }
+
+        private static int ParseInt(string value, int fallback)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return fallback;
+            }
+
+            int result;
+            if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out result))
+            {
+                return result;
+            }
+
+            return fallback;
+        }
+
+        private static bool ParseBool(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return false;
+            }
+
+            return string.Equals(value, "true", StringComparison.OrdinalIgnoreCase) || string.Equals(value, "1", StringComparison.OrdinalIgnoreCase) || string.Equals(value, "yes", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static Color? ParseColor(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return null;
+            }
+
+            try
+            {
+                if (value.StartsWith("#"))
+                {
+                    string text = value.Substring(1);
+                    if (text.Length == 6)
+                    {
+                        int r = int.Parse(text.Substring(0, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+                        int g = int.Parse(text.Substring(2, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+                        int b = int.Parse(text.Substring(4, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+                        return Color.FromArgb(r, g, b);
+                    }
+                    if (text.Length == 8)
+                    {
+                        int a = int.Parse(text.Substring(0, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+                        int r = int.Parse(text.Substring(2, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+                        int g = int.Parse(text.Substring(4, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+                        int b = int.Parse(text.Substring(6, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+                        return Color.FromArgb(a, r, g, b);
+                    }
+                }
+                else
+                {
+                    return Color.FromName(value);
+                }
+            }
+            catch
+            {
+            }
+
+            return null;
+        }
+
+        private static string ColorToString(Color color)
+        {
+            if (color.A == 255)
+            {
+                return string.Concat("#", color.R.ToString("X2", CultureInfo.InvariantCulture), color.G.ToString("X2", CultureInfo.InvariantCulture), color.B.ToString("X2", CultureInfo.InvariantCulture));
+            }
+
+            return string.Concat("#", color.A.ToString("X2", CultureInfo.InvariantCulture), color.R.ToString("X2", CultureInfo.InvariantCulture), color.G.ToString("X2", CultureInfo.InvariantCulture), color.B.ToString("X2", CultureInfo.InvariantCulture));
+        }
+
+        private static FontLayout ParseFont(string value)
+        {
+            string[] parts = value.Split(new char[1] { ',' });
+            if (parts.Length < 2)
+            {
+                return null;
+            }
+
+            FontLayout layout = new FontLayout();
+            layout.Family = parts[0];
+            float size;
+            if (float.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out size))
+            {
+                layout.Size = size;
+            }
+            else
+            {
+                layout.Size = SystemFonts.DefaultFont.Size;
+            }
+
+            FontStyle style = FontStyle.Regular;
+            if (parts.Length > 2)
+            {
+                try
+                {
+                    style = (FontStyle)Enum.Parse(typeof(FontStyle), parts[2], true);
+                }
+                catch
+                {
+                }
+            }
+            layout.Style = style;
+            return layout;
+        }
+
+        private static string FontToString(FontLayout font)
+        {
+            return string.Concat(font.Family, ",", font.Size.ToString(CultureInfo.InvariantCulture), ",", font.Style.ToString());
+        }
+
+        private static string GetAttribute(XmlNode node, string name)
+        {
+            XmlAttribute attribute = node.Attributes[name];
+            return attribute == null ? null : attribute.Value;
+        }
+    }
+}

--- a/Launcher/Layout/LayoutRuntime.cs
+++ b/Launcher/Layout/LayoutRuntime.cs
@@ -1,0 +1,601 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Drawing;
+using System.IO;
+using System.Windows.Forms;
+
+namespace Launcher.Layout
+{
+    public enum SkinVisualState
+    {
+        Normal,
+        Hover,
+        Pressed,
+        Disabled,
+        Checked,
+        Unchecked,
+        Blink
+    }
+
+    public struct LayoutAction
+    {
+        public string Name;
+        public string Argument;
+
+        public LayoutAction(string name, string argument)
+        {
+            this.Name = name;
+            this.Argument = argument;
+        }
+
+        public bool IsEmpty
+        {
+            get { return string.IsNullOrEmpty(this.Name); }
+        }
+    }
+
+    internal class SkinImageSet
+    {
+        public Image Normal;
+        public Image Hover;
+        public Image Pressed;
+        public Image Disabled;
+        public Image Checked;
+        public Image Unchecked;
+        public Image Blink;
+
+        public bool Apply(PictureBox box, SkinVisualState state)
+        {
+            Image image = this.GetImage(state);
+            if (image == null)
+            {
+                return false;
+            }
+
+            box.BackgroundImage = image;
+            return true;
+        }
+
+        public Image GetImage(SkinVisualState state)
+        {
+            switch (state)
+            {
+                case SkinVisualState.Normal:
+                    return this.Normal ?? this.Hover ?? this.Pressed ?? this.Disabled ?? this.Checked ?? this.Unchecked ?? this.Blink;
+                case SkinVisualState.Hover:
+                    return this.Hover;
+                case SkinVisualState.Pressed:
+                    return this.Pressed;
+                case SkinVisualState.Disabled:
+                    return this.Disabled;
+                case SkinVisualState.Checked:
+                    return this.Checked;
+                case SkinVisualState.Unchecked:
+                    return this.Unchecked;
+                case SkinVisualState.Blink:
+                    return this.Blink;
+            }
+
+            return null;
+        }
+    }
+
+    public class LayoutRuntimeContext
+    {
+        private readonly Dictionary<string, Control> controlsByName;
+        private readonly Dictionary<string, SkinImageSet> skinsByName;
+        private readonly Dictionary<PictureBox, SkinImageSet> skinsByControl;
+        private readonly Dictionary<Control, LayoutAction> actions;
+        private readonly Dictionary<PictureBox, bool> toggleStates;
+
+        internal LayoutRuntimeContext()
+        {
+            this.controlsByName = new Dictionary<string, Control>(StringComparer.OrdinalIgnoreCase);
+            this.skinsByName = new Dictionary<string, SkinImageSet>(StringComparer.OrdinalIgnoreCase);
+            this.skinsByControl = new Dictionary<PictureBox, SkinImageSet>();
+            this.actions = new Dictionary<Control, LayoutAction>();
+            this.toggleStates = new Dictionary<PictureBox, bool>();
+        }
+
+        internal void RegisterControl(Control control)
+        {
+            if (control == null)
+            {
+                return;
+            }
+
+            if (!this.controlsByName.ContainsKey(control.Name))
+            {
+                this.controlsByName.Add(control.Name, control);
+            }
+        }
+
+        internal void RegisterSkin(string name, PictureBox control, SkinImageSet skin, bool? initialToggle)
+        {
+            if (control == null || skin == null)
+            {
+                return;
+            }
+
+            if (!this.skinsByName.ContainsKey(name))
+            {
+                this.skinsByName.Add(name, skin);
+            }
+            this.skinsByControl[control] = skin;
+            if (initialToggle.HasValue)
+            {
+                this.toggleStates[control] = initialToggle.Value;
+            }
+        }
+
+        internal void RegisterAction(PictureBox control, LayoutAction action)
+        {
+            if (control == null)
+            {
+                return;
+            }
+
+            this.actions[control] = action;
+        }
+
+        public bool SetState(string name, SkinVisualState state)
+        {
+            Control control;
+            if (!this.controlsByName.TryGetValue(name, out control))
+            {
+                return false;
+            }
+
+            PictureBox pictureBox = control as PictureBox;
+            if (pictureBox == null)
+            {
+                return false;
+            }
+
+            return this.SetState(pictureBox, state);
+        }
+
+        public bool SetState(PictureBox control, SkinVisualState state)
+        {
+            SkinImageSet skin;
+            if (!this.skinsByControl.TryGetValue(control, out skin))
+            {
+                return false;
+            }
+
+            bool applied = skin.Apply(control, state);
+            if (applied && (state == SkinVisualState.Checked || state == SkinVisualState.Unchecked))
+            {
+                this.toggleStates[control] = state == SkinVisualState.Checked;
+            }
+            return applied;
+        }
+
+        public bool ToggleState(PictureBox control)
+        {
+            SkinImageSet skin;
+            if (!this.skinsByControl.TryGetValue(control, out skin))
+            {
+                return false;
+            }
+
+            bool isChecked;
+            if (!this.toggleStates.TryGetValue(control, out isChecked))
+            {
+                isChecked = false;
+            }
+
+            isChecked = !isChecked;
+            this.toggleStates[control] = isChecked;
+            SkinVisualState target = isChecked ? SkinVisualState.Checked : SkinVisualState.Unchecked;
+            if (!skin.Apply(control, target))
+            {
+                skin.Apply(control, SkinVisualState.Normal);
+            }
+            return true;
+        }
+
+        public bool SetToggleState(PictureBox control, bool isChecked)
+        {
+            SkinImageSet skin;
+            if (!this.skinsByControl.TryGetValue(control, out skin))
+            {
+                return false;
+            }
+
+            this.toggleStates[control] = isChecked;
+            SkinVisualState state = isChecked ? SkinVisualState.Checked : SkinVisualState.Unchecked;
+            if (!skin.Apply(control, state))
+            {
+                skin.Apply(control, SkinVisualState.Normal);
+            }
+            return true;
+        }
+
+        public bool TryBlink(PictureBox control, ref bool blinkFlag)
+        {
+            SkinImageSet skin;
+            if (!this.skinsByControl.TryGetValue(control, out skin))
+            {
+                return false;
+            }
+
+            if (skin.Blink == null)
+            {
+                return false;
+            }
+
+            if (blinkFlag)
+            {
+                skin.Apply(control, SkinVisualState.Normal);
+            }
+            else
+            {
+                skin.Apply(control, SkinVisualState.Blink);
+            }
+
+            blinkFlag = !blinkFlag;
+            return true;
+        }
+
+        public bool TryGetAction(Control control, out LayoutAction action)
+        {
+            return this.actions.TryGetValue(control, out action);
+        }
+    }
+
+    public static class LayoutRuntimeApplier
+    {
+        public static LayoutRuntimeContext ApplyLayout(pForm form, LayoutDefinition layout, string layoutPath)
+        {
+            if (layout == null || form == null)
+            {
+                return null;
+            }
+
+            LayoutRuntimeContext context = new LayoutRuntimeContext();
+            RegisterControls(form, context);
+
+            string baseDirectory = Path.GetDirectoryName(layoutPath);
+            string assetDirectory = baseDirectory;
+            if (!string.IsNullOrEmpty(layout.AssetDirectoryName))
+            {
+                string candidate = Path.Combine(baseDirectory, layout.AssetDirectoryName);
+                if (Directory.Exists(candidate))
+                {
+                    assetDirectory = candidate;
+                }
+            }
+
+            ApplyFormSettings(form, layout.Form, assetDirectory);
+            ApplyControls(form, layout, context, assetDirectory);
+            ApplyButtons(form, layout, context, assetDirectory);
+            ApplyDynamicButtons(form, layout, context, assetDirectory);
+            return context;
+        }
+
+        private static void RegisterControls(Control parent, LayoutRuntimeContext context)
+        {
+            context.RegisterControl(parent);
+            foreach (Control child in parent.Controls)
+            {
+                RegisterControls(child, context);
+            }
+        }
+
+        private static void ApplyFormSettings(pForm form, FormLayout layout, string assetDirectory)
+        {
+            if (layout == null)
+            {
+                return;
+            }
+
+            if (!layout.ClientSize.IsEmpty)
+            {
+                form.ClientSize = layout.ClientSize;
+            }
+
+            Image background = LoadImage(assetDirectory, layout.BackgroundImage);
+            if (background != null)
+            {
+                form.BackgroundImage = background;
+            }
+
+            if (!string.IsNullOrEmpty(layout.Caption))
+            {
+                form.Text = layout.Caption;
+            }
+
+            if (layout.TransparencyKey.HasValue)
+            {
+                form.TransparencyKey = layout.TransparencyKey.Value;
+            }
+
+            if (!string.IsNullOrEmpty(layout.Icon))
+            {
+                string iconPath = Path.Combine(assetDirectory, layout.Icon);
+                if (File.Exists(iconPath))
+                {
+                    try
+                    {
+                        form.Icon = new Icon(iconPath);
+                    }
+                    catch
+                    {
+                    }
+                }
+            }
+
+            if (layout.ShowIcon.HasValue)
+            {
+                form.ShowIcon = layout.ShowIcon.Value;
+            }
+        }
+
+        private static void ApplyControls(pForm form, LayoutDefinition layout, LayoutRuntimeContext context, string assetDirectory)
+        {
+            for (int i = 0; i < layout.Controls.Count; i++)
+            {
+                LayoutControl definition = layout.Controls[i];
+                if (definition.Name == null || definition.Name.Length == 0)
+                {
+                    continue;
+                }
+
+                Control[] matches = form.Controls.Find(definition.Name, true);
+                if (matches == null || matches.Length == 0)
+                {
+                    continue;
+                }
+
+                Control control = matches[0];
+                ApplyControlProperties(control, definition, assetDirectory);
+                context.RegisterControl(control);
+            }
+        }
+
+        private static void ApplyButtons(pForm form, LayoutDefinition layout, LayoutRuntimeContext context, string assetDirectory)
+        {
+            for (int i = 0; i < layout.ImageButtons.Count; i++)
+            {
+                ImageButtonDefinition button = layout.ImageButtons[i];
+                if (button.Target == null || button.Target.Length == 0)
+                {
+                    continue;
+                }
+
+                Control[] matches = form.Controls.Find(button.Target, true);
+                if (matches == null || matches.Length == 0)
+                {
+                    continue;
+                }
+
+                PictureBox pictureBox = matches[0] as PictureBox;
+                if (pictureBox == null)
+                {
+                    continue;
+                }
+
+                SkinImageSet skin = LoadSkin(assetDirectory, button.Visuals);
+                context.RegisterSkin(button.Target, pictureBox, skin, button.Checkable ? (bool?)false : null);
+                if (!pictureBox.Enabled)
+                {
+                    if (!context.SetState(pictureBox, SkinVisualState.Disabled))
+                    {
+                        context.SetState(pictureBox, SkinVisualState.Normal);
+                    }
+                }
+                else
+                {
+                    context.SetState(pictureBox, SkinVisualState.Normal);
+                }
+            }
+        }
+
+        private static void ApplyDynamicButtons(pForm form, LayoutDefinition layout, LayoutRuntimeContext context, string assetDirectory)
+        {
+            for (int i = 0; i < layout.DynamicButtons.Count; i++)
+            {
+                DynamicButtonDefinition definition = layout.DynamicButtons[i];
+                PictureBox control = new PictureBox();
+                control.Name = string.IsNullOrEmpty(definition.Name) ? ("dynamicButton" + i.ToString()) : definition.Name;
+                control.BackColor = Color.Transparent;
+                control.Location = definition.Location;
+                control.Size = definition.Size;
+                control.Visible = definition.Visible;
+                control.Enabled = definition.Enabled;
+                control.Cursor = Cursors.Hand;
+                control.BackgroundImageLayout = ParseLayout(definition.BackgroundLayout);
+                if (definition.SizeMode.HasValue)
+                {
+                    control.SizeMode = definition.SizeMode.Value;
+                }
+                else
+                {
+                    control.SizeMode = PictureBoxSizeMode.Normal;
+                }
+
+                SkinImageSet skin = LoadSkin(assetDirectory, definition.Visuals);
+                if (!context.SetState(control, SkinVisualState.Normal))
+                {
+                    Image normal = skin.GetImage(SkinVisualState.Normal);
+                    if (normal != null)
+                    {
+                        control.BackgroundImage = normal;
+                    }
+                }
+
+                form.Controls.Add(control);
+                control.BringToFront();
+                form.RegisterDynamicButtonControl(control);
+
+                control.Click += new EventHandler(form.LayoutDynamicButton_Click);
+                control.MouseEnter += new EventHandler(form.LayoutDynamicButton_MouseEnter);
+                control.MouseLeave += new EventHandler(form.LayoutDynamicButton_MouseLeave);
+                control.MouseDown += new MouseEventHandler(form.LayoutDynamicButton_MouseDown);
+                control.MouseUp += new MouseEventHandler(form.LayoutDynamicButton_MouseUp);
+
+                context.RegisterControl(control);
+                context.RegisterSkin(control.Name, control, skin, definition.Checkable ? (bool?)false : null);
+                context.RegisterAction(control, new LayoutAction(definition.Action, definition.Argument));
+                context.SetState(control, SkinVisualState.Normal);
+            }
+        }
+
+        private static void ApplyControlProperties(Control control, LayoutControl definition, string assetDirectory)
+        {
+            control.Location = definition.Location;
+            if (!definition.Size.IsEmpty)
+            {
+                control.Size = definition.Size;
+            }
+
+            if (definition.Visible.HasValue)
+            {
+                control.Visible = definition.Visible.Value;
+            }
+
+            if (definition.Enabled.HasValue)
+            {
+                control.Enabled = definition.Enabled.Value;
+            }
+
+            Label label = control as Label;
+            if (label != null)
+            {
+                if (definition.AutoSize.HasValue)
+                {
+                    label.AutoSize = definition.AutoSize.Value;
+                }
+                if (!string.IsNullOrEmpty(definition.Text))
+                {
+                    label.Text = definition.Text;
+                }
+                if (definition.ForeColor.HasValue)
+                {
+                    label.ForeColor = definition.ForeColor.Value;
+                }
+                if (definition.BackColor.HasValue)
+                {
+                    label.BackColor = definition.BackColor.Value;
+                }
+                if (definition.Font != null)
+                {
+                    try
+                    {
+                        label.Font = definition.Font.ToFont();
+                    }
+                    catch
+                    {
+                    }
+                }
+                if (definition.TextAlign.HasValue)
+                {
+                    label.TextAlign = definition.TextAlign.Value;
+                }
+            }
+
+            PictureBox pictureBox = control as PictureBox;
+            if (pictureBox != null)
+            {
+                if (definition.SizeMode.HasValue)
+                {
+                    pictureBox.SizeMode = definition.SizeMode.Value;
+                }
+                pictureBox.BackgroundImageLayout = ParseLayout(definition.BackgroundLayout);
+                Image background = LoadImage(assetDirectory, definition.BackgroundImage);
+                if (background != null)
+                {
+                    pictureBox.BackgroundImage = background;
+                }
+                Image foreground = LoadImage(assetDirectory, definition.Image);
+                if (foreground != null)
+                {
+                    pictureBox.Image = foreground;
+                }
+            }
+
+            WebBrowser browser = control as WebBrowser;
+            if (browser != null)
+            {
+                if (!string.IsNullOrEmpty(definition.Url))
+                {
+                    try
+                    {
+                        browser.Url = new Uri(definition.Url, UriKind.RelativeOrAbsolute);
+                    }
+                    catch
+                    {
+                    }
+                }
+            }
+        }
+
+        private static ImageLayout ParseLayout(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return ImageLayout.None;
+            }
+
+            try
+            {
+                return (ImageLayout)Enum.Parse(typeof(ImageLayout), value, true);
+            }
+            catch
+            {
+                return ImageLayout.None;
+            }
+        }
+
+        private static SkinImageSet LoadSkin(string baseDirectory, ButtonVisuals visuals)
+        {
+            SkinImageSet skin = new SkinImageSet();
+            skin.Normal = LoadImage(baseDirectory, visuals.Normal);
+            skin.Hover = LoadImage(baseDirectory, visuals.Hover);
+            skin.Pressed = LoadImage(baseDirectory, visuals.Pressed);
+            skin.Disabled = LoadImage(baseDirectory, visuals.Disabled);
+            skin.Checked = LoadImage(baseDirectory, visuals.Checked);
+            skin.Unchecked = LoadImage(baseDirectory, visuals.Unchecked);
+            skin.Blink = LoadImage(baseDirectory, visuals.Blink);
+            return skin;
+        }
+
+        internal static Image LoadImage(string baseDirectory, string relativePath)
+        {
+            if (string.IsNullOrEmpty(relativePath))
+            {
+                return null;
+            }
+
+            string path = Path.Combine(baseDirectory, relativePath.Replace('/', Path.DirectorySeparatorChar));
+            if (!File.Exists(path))
+            {
+                return null;
+            }
+
+            try
+            {
+                using (FileStream stream = File.OpenRead(path))
+                {
+                    using (MemoryStream memoryStream = new MemoryStream())
+                    {
+                        byte[] buffer = new byte[4096];
+                        int read;
+                        while ((read = stream.Read(buffer, 0, buffer.Length)) > 0)
+                        {
+                            memoryStream.Write(buffer, 0, read);
+                        }
+                        memoryStream.Position = 0L;
+                        return Image.FromStream(memoryStream);
+                    }
+                }
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/Launcher/layout/launcher.layout.xml
+++ b/Launcher/layout/launcher.layout.xml
@@ -1,0 +1,19 @@
+<layout basePath="assets">
+  <form width="990" height="560" background="backgrounds/main.png" transparency="#FF00FF" caption="Autoupdate" showIcon="false" />
+  <control name="Status" type="Label" x="176" y="503" width="42" height="14" text="Status" foreColor="#FFFFFF" backColor="Transparent" font="Tahoma,8.75,Regular" autoSize="true" />
+  <control name="pictureBox1" type="PictureBox" x="840" y="503" width="146" height="53" backgroundLayout="Stretch" />
+  <control name="pictureBox2" type="PictureBox" x="968" y="3" width="18" height="18" />
+  <control name="pictureBox3" type="PictureBox" x="947" y="3" width="18" height="18" />
+  <control name="pictureBox4" type="PictureBox" x="818" y="541" width="16" height="15" />
+  <control name="label1" type="Label" x="760" y="543" width="52" height="13" text="Winmode" foreColor="#B0C4DE" backColor="Transparent" font="Tahoma,8,Regular" />
+  <control name="label2" type="Label" x="26" y="3" width="86" height="14" text="MU Launcher" foreColor="#B0C4DE" backColor="Transparent" font="Tahoma,9,Bold" />
+  <control name="CopyRightLabel" type="Label" x="108" y="543" width="136" height="14" text="Coded by MyHeart (RZ)" foreColor="#808080" backColor="Transparent" font="Tahoma,8.3,Regular" />
+  <control name="webBrowser1" type="WebBrowser" x="5" y="23" width="979" height="475" />
+  <control name="pictureBox5" type="PictureBox" x="179" y="524" width="619" height="11" backgroundLayout="Stretch" />
+  <control name="pictureBox6" type="PictureBox" x="179" y="524" width="0" height="11" sizeMode="StretchImage" />
+  <imageButton target="pictureBox1" normal="buttons/start_normal.png" hover="buttons/start_hover.png" pressed="buttons/start_pressed.png" disabled="buttons/start_disabled.png" blink="buttons/start_blink.png" />
+  <imageButton target="pictureBox2" normal="buttons/exit_normal.png" hover="buttons/exit_hover.png" pressed="buttons/exit_pressed.png" />
+  <imageButton target="pictureBox3" normal="buttons/options_normal.png" hover="buttons/options_hover.png" pressed="buttons/options_pressed.png" />
+  <toggleButton target="pictureBox4" unchecked="buttons/window_unchecked.png" checked="buttons/window_checked.png" hover="buttons/window_hover.png" />
+  <dynamicButton name="SampleButton" x="32" y="520" width="140" height="28" normal="buttons/sample_normal.png" hover="buttons/sample_hover.png" pressed="buttons/sample_pressed.png" action="OpenUrl" argument="https://example.com" visible="false" />
+</layout>

--- a/Launcher/pForm.cs
+++ b/Launcher/pForm.cs
@@ -1,5 +1,7 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Management;
@@ -8,6 +10,7 @@ using System.Windows.Forms;
 using IniParser;
 using IniParser.Model;
 using Launcher.Exile;
+using Launcher.Layout;
 using Launcher.Properties;
 using Microsoft.Win32;
 
@@ -15,6 +18,9 @@ namespace Launcher
 {
 	public partial class pForm : Form
 	{
+        private LayoutRuntimeContext layoutContext;
+        private readonly List<PictureBox> layoutDynamicButtons = new List<PictureBox>();
+
         public pForm()
         {
             this.InitializeComponent();
@@ -26,6 +32,70 @@ namespace Launcher
             if (str1 == "1")
                 Globals.UseSeason12 = true;
             Globals.pForm = this;
+            this.LoadExternalLayout();
+            Globals.Caption = this.Text;
+        }
+
+        private void LoadExternalLayout()
+        {
+            this.RemoveLayoutDynamicButtons();
+            this.layoutContext = null;
+            Globals.LayoutContext = null;
+            try
+            {
+                string baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
+                string layoutDirectory = Path.Combine(baseDirectory, "layout");
+                string layoutFile = Path.Combine(layoutDirectory, "launcher.layout.xml");
+                if (!File.Exists(layoutFile))
+                {
+                    return;
+                }
+
+                LayoutDefinition definition = LayoutFile.Load(layoutFile);
+                LayoutRuntimeContext context = LayoutRuntimeApplier.ApplyLayout(this, definition, layoutFile);
+                this.layoutContext = context;
+                Globals.LayoutContext = context;
+                if (context != null)
+                {
+                    Globals.Caption = this.Text;
+                }
+            }
+            catch
+            {
+            }
+        }
+
+        private void RemoveLayoutDynamicButtons()
+        {
+            for (int i = 0; i < this.layoutDynamicButtons.Count; i++)
+            {
+                PictureBox control = this.layoutDynamicButtons[i];
+                if (control == null)
+                {
+                    continue;
+                }
+                control.Click -= new EventHandler(this.LayoutDynamicButton_Click);
+                control.MouseEnter -= new EventHandler(this.LayoutDynamicButton_MouseEnter);
+                control.MouseLeave -= new EventHandler(this.LayoutDynamicButton_MouseLeave);
+                control.MouseDown -= new MouseEventHandler(this.LayoutDynamicButton_MouseDown);
+                control.MouseUp -= new MouseEventHandler(this.LayoutDynamicButton_MouseUp);
+                if (control.Parent == this)
+                {
+                    this.Controls.Remove(control);
+                }
+                control.Dispose();
+            }
+            this.layoutDynamicButtons.Clear();
+        }
+
+        internal void RegisterDynamicButtonControl(PictureBox control)
+        {
+            if (control == null)
+            {
+                return;
+            }
+
+            this.layoutDynamicButtons.Add(control);
         }
 
         private void pForm_Shown(object sender, EventArgs e)
@@ -80,12 +150,18 @@ namespace Launcher
                     if (num == 1)
                     {
                         subKey.SetValue("WindowMode", (object)0, RegistryValueKind.DWord);
-                        this.pictureBox4.BackgroundImage = (Image)Resources.windowmode_uncheck;
+                        if (this.layoutContext == null || !this.layoutContext.SetToggleState(this.pictureBox4, false))
+                        {
+                            this.pictureBox4.BackgroundImage = (Image)Resources.windowmode_uncheck;
+                        }
                     }
                     else
                     {
                         subKey.SetValue("WindowMode", (object)1, RegistryValueKind.DWord);
-                        this.pictureBox4.BackgroundImage = (Image)Resources.windowmode;
+                        if (this.layoutContext == null || !this.layoutContext.SetToggleState(this.pictureBox4, true))
+                        {
+                            this.pictureBox4.BackgroundImage = (Image)Resources.windowmode;
+                        }
                     }
                     subKey.Close();
                 }
@@ -101,12 +177,18 @@ namespace Launcher
                     if (System.IO.File.ReadAllLines(str)[1] == "WindowMode:1")
                     {
                         Common.lineChanger("WindowMode:0", str, 2);
-                        this.pictureBox4.BackgroundImage = (Image)Resources.windowmode_uncheck;
+                        if (this.layoutContext == null || !this.layoutContext.SetToggleState(this.pictureBox4, false))
+                        {
+                            this.pictureBox4.BackgroundImage = (Image)Resources.windowmode_uncheck;
+                        }
                     }
                     else
                     {
                         Common.lineChanger("WindowMode:1", str, 2);
-                        this.pictureBox4.BackgroundImage = (Image)Resources.windowmode;
+                        if (this.layoutContext == null || !this.layoutContext.SetToggleState(this.pictureBox4, true))
+                        {
+                            this.pictureBox4.BackgroundImage = (Image)Resources.windowmode;
+                        }
                     }
                 }
                 catch
@@ -123,7 +205,10 @@ namespace Launcher
                     }
                     else
                         Common.lineChanger("WindowMode:1", str, 2);
-                    this.pictureBox4.BackgroundImage = (Image)Resources.windowmode;
+                    if (this.layoutContext == null || !this.layoutContext.SetToggleState(this.pictureBox4, true))
+                    {
+                        this.pictureBox4.BackgroundImage = (Image)Resources.windowmode;
+                    }
                 }
             }
         }
@@ -142,6 +227,185 @@ namespace Launcher
         private void pictureBox6_Click(object sender, EventArgs e)
         {
             this.WindowState = FormWindowState.Minimized;
+        }
+
+        internal void LayoutDynamicButton_Click(object sender, EventArgs e)
+        {
+            if (this.layoutContext == null)
+            {
+                return;
+            }
+
+            PictureBox control = sender as PictureBox;
+            if (control == null)
+            {
+                return;
+            }
+
+            LayoutAction action;
+            if (this.layoutContext.TryGetAction(control, out action))
+            {
+                this.ExecuteLayoutAction(action, control);
+            }
+        }
+
+        internal void LayoutDynamicButton_MouseEnter(object sender, EventArgs e)
+        {
+            PictureBox control = sender as PictureBox;
+            if (control == null)
+            {
+                return;
+            }
+
+            if (this.layoutContext != null && this.layoutContext.SetState(control, SkinVisualState.Hover))
+            {
+                return;
+            }
+        }
+
+        internal void LayoutDynamicButton_MouseLeave(object sender, EventArgs e)
+        {
+            PictureBox control = sender as PictureBox;
+            if (control == null)
+            {
+                return;
+            }
+
+            if (this.layoutContext != null && this.layoutContext.SetState(control, SkinVisualState.Normal))
+            {
+                return;
+            }
+        }
+
+        internal void LayoutDynamicButton_MouseDown(object sender, MouseEventArgs e)
+        {
+            PictureBox control = sender as PictureBox;
+            if (control == null)
+            {
+                return;
+            }
+
+            if (this.layoutContext != null && this.layoutContext.SetState(control, SkinVisualState.Pressed))
+            {
+                return;
+            }
+        }
+
+        internal void LayoutDynamicButton_MouseUp(object sender, MouseEventArgs e)
+        {
+            PictureBox control = sender as PictureBox;
+            if (control == null)
+            {
+                return;
+            }
+
+            if (this.layoutContext != null && this.layoutContext.SetState(control, SkinVisualState.Hover))
+            {
+                return;
+            }
+        }
+
+        private void ExecuteLayoutAction(LayoutAction action, PictureBox source)
+        {
+            if (action.IsEmpty)
+            {
+                return;
+            }
+
+            string name = action.Name;
+            string argument = action.Argument;
+            try
+            {
+                if (string.Equals(name, "Start", StringComparison.OrdinalIgnoreCase))
+                {
+                    this.pictureBox1_Click(this.pictureBox1, EventArgs.Empty);
+                }
+                else if (string.Equals(name, "Exit", StringComparison.OrdinalIgnoreCase))
+                {
+                    this.Close();
+                }
+                else if (string.Equals(name, "Options", StringComparison.OrdinalIgnoreCase) || string.Equals(name, "ShowOptions", StringComparison.OrdinalIgnoreCase))
+                {
+                    this.pictureBox3_Click(this.pictureBox3, EventArgs.Empty);
+                }
+                else if (string.Equals(name, "ToggleWindowMode", StringComparison.OrdinalIgnoreCase))
+                {
+                    this.pictureBox4_Click(this.pictureBox4, EventArgs.Empty);
+                }
+                else if (string.Equals(name, "ToggleState", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (this.layoutContext != null && source != null)
+                    {
+                        this.layoutContext.ToggleState(source);
+                    }
+                }
+                else if (string.Equals(name, "Minimize", StringComparison.OrdinalIgnoreCase))
+                {
+                    this.WindowState = FormWindowState.Minimized;
+                }
+                else if (string.Equals(name, "OpenUrl", StringComparison.OrdinalIgnoreCase))
+                {
+                    this.OpenExternalResource(argument);
+                }
+                else if (string.Equals(name, "Run", StringComparison.OrdinalIgnoreCase) || string.Equals(name, "Launch", StringComparison.OrdinalIgnoreCase) || string.Equals(name, "OpenFile", StringComparison.OrdinalIgnoreCase))
+                {
+                    this.StartProcess(argument);
+                }
+                else if (string.Equals(name, "OpenFolder", StringComparison.OrdinalIgnoreCase))
+                {
+                    this.StartProcess(argument);
+                }
+                else if (string.Equals(name, "Message", StringComparison.OrdinalIgnoreCase))
+                {
+                    MessageBox.Show(string.IsNullOrEmpty(argument) ? string.Empty : argument, Globals.Caption);
+                }
+            }
+            catch
+            {
+            }
+        }
+
+        private void OpenExternalResource(string url)
+        {
+            if (string.IsNullOrEmpty(url))
+            {
+                return;
+            }
+            try
+            {
+                Process.Start(url);
+            }
+            catch
+            {
+                try
+                {
+                    string escaped = url.Replace("\"", "\"\"");
+                    string arguments = string.Concat("/c start \"\" \"", escaped, "\"");
+                    ProcessStartInfo info = new ProcessStartInfo("cmd", arguments);
+                    info.CreateNoWindow = true;
+                    info.UseShellExecute = false;
+                    Process.Start(info);
+                }
+                catch
+                {
+                }
+            }
+        }
+
+        private void StartProcess(string target)
+        {
+            if (string.IsNullOrEmpty(target))
+            {
+                return;
+            }
+
+            try
+            {
+                Process.Start(target);
+            }
+            catch
+            {
+            }
         }
 
         private void pForm_MouseDown(object sender, MouseEventArgs e)
@@ -177,16 +441,30 @@ namespace Launcher
                     RegistryKey registryKey = Registry.CurrentUser.OpenSubKey("Software\\Webzen\\Mu\\Config");
                     if (registryKey != null)
                     {
-                        if (registryKey.GetValue("WindowMode") != null)
+                        object value = registryKey.GetValue("WindowMode");
+                        if (value != null)
                         {
-                            if ((int)registryKey.GetValue("WindowMode") == 1)
-                                this.pictureBox4.BackgroundImage = (Image)Resources.windowmode;
+                            if ((int)value == 1)
+                            {
+                                if (this.layoutContext == null || !this.layoutContext.SetToggleState(this.pictureBox4, true))
+                                {
+                                    this.pictureBox4.BackgroundImage = (Image)Resources.windowmode;
+                                }
+                            }
+                            else if (this.layoutContext == null || !this.layoutContext.SetToggleState(this.pictureBox4, false))
+                            {
+                                this.pictureBox4.BackgroundImage = (Image)Resources.windowmode_uncheck;
+                            }
                         }
                         else
                         {
                             registryKey = Registry.CurrentUser.CreateSubKey("Software\\Webzen\\Mu\\Config");
                             registryKey.CreateSubKey("WindowMode");
                             registryKey.SetValue("WindowMode", (object)0, RegistryValueKind.DWord);
+                            if (this.layoutContext == null || !this.layoutContext.SetToggleState(this.pictureBox4, false))
+                            {
+                                this.pictureBox4.BackgroundImage = (Image)Resources.windowmode_uncheck;
+                            }
                         }
                     }
                     else
@@ -194,6 +472,10 @@ namespace Launcher
                         registryKey = Registry.CurrentUser.CreateSubKey("Software\\Webzen\\Mu\\Config");
                         registryKey.CreateSubKey("WindowMode");
                         registryKey.SetValue("WindowMode", (object)0, RegistryValueKind.DWord);
+                        if (this.layoutContext == null || !this.layoutContext.SetToggleState(this.pictureBox4, false))
+                        {
+                            this.pictureBox4.BackgroundImage = (Image)Resources.windowmode_uncheck;
+                        }
                     }
                     registryKey.Close();
                 }
@@ -205,8 +487,18 @@ namespace Launcher
             {
                 try
                 {
-                    if (System.IO.File.ReadAllLines("LauncherOption.if")[1] == "WindowMode:1")
-                        this.pictureBox4.BackgroundImage = (Image)Resources.windowmode;
+                    string[] lines = System.IO.File.ReadAllLines("LauncherOption.if");
+                    if (lines.Length > 1 && lines[1] == "WindowMode:1")
+                    {
+                        if (this.layoutContext == null || !this.layoutContext.SetToggleState(this.pictureBox4, true))
+                        {
+                            this.pictureBox4.BackgroundImage = (Image)Resources.windowmode;
+                        }
+                    }
+                    else if (this.layoutContext == null || !this.layoutContext.SetToggleState(this.pictureBox4, false))
+                    {
+                        this.pictureBox4.BackgroundImage = (Image)Resources.windowmode_uncheck;
+                    }
                 }
                 catch
                 {
@@ -216,33 +508,59 @@ namespace Launcher
 
         private void pictureBox1_MouseDown(object sender, MouseEventArgs e)
         {
+            if (this.layoutContext != null && this.layoutContext.SetState(this.pictureBox1, SkinVisualState.Pressed))
+            {
+                return;
+            }
             this.pictureBox1.BackgroundImage = (Image)Resources.start_3;
         }
 
         private void pictureBox1_MouseHover(object sender, EventArgs e)
         {
+            if (this.layoutContext != null && this.layoutContext.SetState(this.pictureBox1, SkinVisualState.Hover))
+            {
+                this.Pic1_Hover = true;
+                return;
+            }
             this.pictureBox1.BackgroundImage = (Image)Resources.start_2;
             this.Pic1_Hover = true;
         }
 
         private void pictureBox1_MouseLeave(object sender, EventArgs e)
         {
+            if (this.layoutContext != null && this.layoutContext.SetState(this.pictureBox1, SkinVisualState.Normal))
+            {
+                this.Pic1_Hover = false;
+                return;
+            }
             this.pictureBox1.BackgroundImage = (Image)Resources.start_1;
             this.Pic1_Hover = false;
         }
 
         private void pictureBox1_MouseUp(object sender, MouseEventArgs e)
         {
+            if (this.layoutContext != null && this.layoutContext.SetState(this.pictureBox1, SkinVisualState.Normal))
+            {
+                return;
+            }
             this.pictureBox1.BackgroundImage = (Image)Resources.start_1;
         }
 
         private void pictureBox3_MouseDown(object sender, MouseEventArgs e)
         {
+            if (this.layoutContext != null && this.layoutContext.SetState(this.pictureBox3, SkinVisualState.Pressed))
+            {
+                return;
+            }
             this.pictureBox3.BackgroundImage = (Image)Resources.setting_3;
         }
 
         private void pictureBox3_MouseUp(object sender, MouseEventArgs e)
         {
+            if (this.layoutContext != null && this.layoutContext.SetState(this.pictureBox3, SkinVisualState.Normal))
+            {
+                return;
+            }
             this.pictureBox3.BackgroundImage = (Image)Resources.setting_1;
         }
 
@@ -256,31 +574,55 @@ namespace Launcher
 
         private void pictureBox2_MouseDown(object sender, MouseEventArgs e)
         {
+            if (this.layoutContext != null && this.layoutContext.SetState(this.pictureBox2, SkinVisualState.Pressed))
+            {
+                return;
+            }
             this.pictureBox2.BackgroundImage = (Image)Resources.exit_3;
         }
 
         private void pictureBox2_MouseHover(object sender, EventArgs e)
         {
+            if (this.layoutContext != null && this.layoutContext.SetState(this.pictureBox2, SkinVisualState.Hover))
+            {
+                return;
+            }
             this.pictureBox2.BackgroundImage = (Image)Resources.exit_2;
         }
 
         private void pictureBox2_MouseLeave(object sender, EventArgs e)
         {
+            if (this.layoutContext != null && this.layoutContext.SetState(this.pictureBox2, SkinVisualState.Normal))
+            {
+                return;
+            }
             this.pictureBox2.BackgroundImage = (Image)Resources.exit_1;
         }
 
         private void pictureBox2_MouseUp(object sender, MouseEventArgs e)
         {
+            if (this.layoutContext != null && this.layoutContext.SetState(this.pictureBox2, SkinVisualState.Normal))
+            {
+                return;
+            }
             this.pictureBox2.BackgroundImage = (Image)Resources.exit_1;
         }
 
         private void pictureBox3_MouseHover(object sender, EventArgs e)
         {
+            if (this.layoutContext != null && this.layoutContext.SetState(this.pictureBox3, SkinVisualState.Hover))
+            {
+                return;
+            }
             this.pictureBox3.BackgroundImage = (Image)Resources.setting_2;
         }
 
         private void pictureBox3_MouseLeave(object sender, EventArgs e)
         {
+            if (this.layoutContext != null && this.layoutContext.SetState(this.pictureBox3, SkinVisualState.Normal))
+            {
+                return;
+            }
             this.pictureBox3.BackgroundImage = (Image)Resources.setting_1;
         }
 
@@ -293,6 +635,10 @@ namespace Launcher
         {
             if (this.Pic1_Hover || !Globals.EnableStartBTN)
                 return;
+            if (this.layoutContext != null && this.layoutContext.TryBlink(this.pictureBox1, ref this.blink))
+            {
+                return;
+            }
             if (this.blink)
                 this.pictureBox1.BackgroundImage = (Image)Resources.start_2;
             else
@@ -308,9 +654,9 @@ namespace Launcher
 
 		private static string InstanceName = "#launcheritself";
 
-		private bool Pic1_Hover = false;
+                private bool Pic1_Hover = false;
 
-		private bool blink = true;
+                private bool blink = false;
 
 		public delegate void DoWorkDelegate();
 	}


### PR DESCRIPTION
## Summary
- add a WinForms layout editor shell that can open/save launcher layout XML, preview assets, and let designers drag dynamic buttons on a live design surface
- expose form, static control, and dynamic button settings through property-grid models with asset file pickers so edits flow back into the XML definition
- check in the shared layout definition/runtime classes and a sample `launcher.layout.xml` that the editor and launcher load to stay in sync

## Testing
- not run (WinForms project requires Windows to execute)


------
https://chatgpt.com/codex/tasks/task_e_68cc4798ea0483329c4ea910299307e3